### PR TITLE
Add fast Verilator VPI simulation support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,11 +77,20 @@ jobs:
           path: regress.log
           if-no-files-found: ignore
 
-  # TinyALU smoke test on the free simulators (Icarus runs it, Verilator
-  # lints it). Commercial simulators (VCS/Questa/Xcelium) cannot run in
-  # public CI — license holders run: sim/run_smoke.sh <sim> locally.
+  # Free-simulator validation. Linux runs every simulator entry; macOS runs
+  # the Verilator entries that exercise runtime loading, scheduling, callback
+  # ownership and the mutation check. Commercial simulators cannot run in
+  # public CI.
   sim-smoke:
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            filter: sim
+          - os: macos-latest
+            filter: verilator
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
 
@@ -95,13 +104,49 @@ jobs:
         with:
           toolchain: ${{ steps.pin.outputs.channel }}
 
-      - name: Install Icarus Verilog and Verilator
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends iverilog verilator
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            rustdv
+            output/examples
+
+      - name: Install simulator build dependencies
+        run: |
+          if [ "$RUNNER_OS" = Linux ]; then
+            sudo apt-get update
+            sudo apt-get install -y --no-install-recommends \
+              iverilog autoconf flex bison help2man pkg-config libfl-dev \
+              zlib1g-dev liblz4-dev curl ca-certificates
+          else
+            brew install icarus-verilog autoconf flex bison help2man pkg-config lz4
+            echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
+            echo "$(brew --prefix flex)/bin" >> "$GITHUB_PATH"
+          fi
+
+      - name: Cache Verilator 5.050
+        id: verilator-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/verilator-5.050
+          key: verilator-5.050-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Build pinned Verilator
+        if: steps.verilator-cache.outputs.cache-hit != 'true'
+        run: bash ci/install-verilator.sh "$RUNNER_TEMP/verilator-5.050"
+
+      - name: Select and verify pinned Verilator
+        run: |
+          echo "$RUNNER_TEMP/verilator-5.050/bin" >> "$GITHUB_PATH"
+          got="$($RUNNER_TEMP/verilator-5.050/bin/verilator --version | awk '{print $2}')"
+          test "$got" = 5.050 || {
+            echo "::error::expected Verilator 5.050, got $got"
+            exit 1
+          }
 
       - name: Run simulator smoke tests
         run: |
           set -o pipefail
-          python3 output/regression/regress.py --suite custom --filter sim 2>&1 | tee sim.log
+          python3 output/regression/regress.py --suite custom --filter '${{ matrix.filter }}' 2>&1 | tee sim.log
 
       - name: Show the failing detail
         if: failure()
@@ -112,17 +157,16 @@ jobs:
           echo "=== verilator version on this runner ==="
           verilator --version || true
           echo
-          echo "=== verilator lint, re-run directly for its own output ==="
-          # regress.py captures a test's stdout, so a lint failure reaches the
-          # log only as "exit 1, expected 0". Re-running prints the actual
-          # warnings. Verilator's lint set moves between releases, so the
-          # version above is the first thing to compare against a local pass.
+          echo "=== verilator smoke, re-run directly for its own output ==="
           bash sim/run_smoke.sh verilator || true
+          echo
+          echo "=== rustdv TinyALU, re-run directly ==="
+          bash sim/run_rustdv.sh release verilator || true
 
       - name: Upload simulator log
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: sim-log
+          name: sim-log-${{ runner.os }}
           path: sim.log
           if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ If you know the UVM, this is the whole translation table.
 
 ## Installation
 
-You need **Rust** and a simulator. rustdv is developed and tested against
-**Icarus Verilog**. This repository pins its toolchain in
+You need **Rust** and a simulator. rustdv uses **Icarus Verilog** as its
+four-state reference and supports **Verilator** for fast two-state functional
+simulation. This repository pins its Rust toolchain in
 [`rust-toolchain.toml`](rust-toolchain.toml), so `rustup` fetches the right
 compiler on its own.
 
@@ -124,11 +125,13 @@ from chapter 18 onward, and the shipped testbench for it is in
 
 ```sh
 sim/run_rustdv.sh
+sim/run_rustdv.sh release verilator
 ```
 
-That builds the testbench as a shared library, compiles the DUT with Icarus,
-and hands the library to `vvp`. There is no Verilog testbench: rustdv drives
-the top module directly.
+Both commands build the same testbench shared library and load it through VPI.
+The first uses Icarus; the second builds the DUT with Verilator and runs it
+through rustdv's shared Verilator host. There is no Verilog testbench: rustdv
+drives the top module directly.
 
 Two tests run. `RandomTest` sends random operands across every operation five
 times each; `MaxTest` sends `0xff op 0xff` once per operation. Here is the
@@ -786,7 +789,7 @@ asserted here.
 | | Status |
 |---|---|
 | Icarus Verilog | full simulation; runs in CI, and every transcript in the book comes from it |
-| Verilator | lints in CI |
+| Verilator | full two-state simulation; FAST, DEBUG/FST, scheduler, and mutation paths run in CI |
 | VCS / Questa / Xcelium | same script (`sim/run_smoke.sh vcs\|questa\|xcelium`); licenses can't live in public CI, so license-holders run the identical regression locally |
 | EDA Playground | HDL side only — it has no Rust toolchain; see [sim/README.md](sim/README.md) |
 

--- a/ci/install-verilator.sh
+++ b/ci/install-verilator.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Build the Verilator release rustdv's runtime VPI loader is verified against.
+# Installs into a caller-owned prefix, so CI and containers need no sudo.
+set -euo pipefail
+
+VERSION=5.050
+SHA256=ec6723f30c1798b1fbbbed97364f09c431fb4875577c314f37240e99b60a4a04
+PREFIX="${1:-/tmp/rustdv-$(id -u)/verilator-$VERSION}"
+
+if [ -x "$PREFIX/bin/verilator" ]; then
+    installed="$($PREFIX/bin/verilator --version | awk '{print $2}')"
+    if [ "$installed" = "$VERSION" ]; then
+        echo "Verilator $VERSION already installed at $PREFIX"
+        exit 0
+    fi
+fi
+
+missing=()
+for tool in curl tar autoconf make flex bison perl python3; do
+    command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+    echo "Verilator build dependencies missing: ${missing[*]}" >&2
+    exit 2
+fi
+
+SCRATCH="/tmp/rustdv-$(id -u)/verilator-install"
+ARCHIVE="$SCRATCH/verilator-v$VERSION.tar.gz"
+mkdir -p "$SCRATCH" "$PREFIX"
+
+if [ ! -f "$ARCHIVE" ]; then
+    curl --fail --location --silent --show-error \
+        "https://github.com/verilator/verilator/archive/refs/tags/v$VERSION.tar.gz" \
+        --output "$ARCHIVE"
+fi
+
+if command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$ARCHIVE" | awk '{print $1}')"
+else
+    echo "Verilator installer needs shasum or sha256sum" >&2
+    exit 2
+fi
+if [ "$actual" != "$SHA256" ]; then
+    echo "Verilator archive checksum mismatch: got $actual, expected $SHA256" >&2
+    exit 1
+fi
+
+SOURCE="$(mktemp -d "$SCRATCH/source.XXXXXX")"
+trap 'rm -rf "$SOURCE"' EXIT
+tar -xzf "$ARCHIVE" -C "$SOURCE" --strip-components=1
+
+jobs="${VERILATOR_BUILD_JOBS:-2}"
+(
+    cd "$SOURCE"
+    autoconf
+    ./configure --prefix="$PREFIX"
+    make -j "$jobs"
+    make install
+)
+
+"$PREFIX/bin/verilator" --version

--- a/output/examples/README.md
+++ b/output/examples/README.md
@@ -16,6 +16,10 @@ the `custom/sim-chNN` regression tests. Shared testbench code lives in
 compile errors, 3 intentional panics, 1 unit-test figure, 3 non-runnable
 fragments, 2 Python contrast figures, and 6 shell transcripts.
 
+Icarus remains the source of the book's four-state transcripts. Set
+`SIM=verilator` when using `sim-common/run_sim.sh` to run the same Rust
+testbench in Verilator's faster two-state mode.
+
 ## Naming convention
 
 ```

--- a/output/examples/sim-common/hdl/tinyalu.sv
+++ b/output/examples/sim-common/hdl/tinyalu.sv
@@ -3,6 +3,7 @@ module tinyalu (input [7:0] A,
 		input [2:0] op,
 		input reset_n,
 		input start,
+		output bit clk,
 		output done,
 		output [15:0] result);
 
@@ -10,7 +11,6 @@ module tinyalu (input [7:0] A,
    // it must on an emulator, where a software-driven clock would cross the
    // hardware boundary on every edge. rustdv generates no clock; BFMs only
    // ever wait on edges. 10ns period at the 1ns/1ns timescale.
-   bit clk;
    initial clk = 0;
    always #5 clk = ~clk;
 

--- a/output/examples/sim-common/run_sim.sh
+++ b/output/examples/sim-common/run_sim.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Build a chapter's sim-figure crate as a VPI module and run it on Icarus.
+# Build a chapter's sim-figure crate as a VPI module and run it on a simulator.
 # Usage: sim-common/run_sim.sh <crate-name> <top-module> [hdl files...]
 #
 # Part II+ figures run inside a simulator; each sim chapter is a cdylib
@@ -7,7 +7,9 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 CRATE="$1"; TOP="$2"; shift 2
+SIM="${SIM:-icarus}"
 HDL=("$@"); [ ${#HDL[@]} -eq 0 ] && HDL=(sim-common/hdl/timescale.v "sim-common/hdl/${TOP}.sv")
+REPO_ROOT="$(cd ../.. && pwd)"
 # Everything scratch lives under one per-user root, /tmp/rustdv-<uid>/.
 # A bare /tmp/rustdv-... path is shared by every account on the machine, so a
 # directory left by someone else makes the build unwritable and the failure
@@ -21,7 +23,19 @@ BUILD="${SIM_BUILD_DIR:-$RUSTDV_TMP/sim}"; mkdir -p "$BUILD"
 # Linux builds lib<crate>.so; macOS builds lib<crate>.dylib
 LIB="$CARGO_TARGET_DIR/release/lib${CRATE}.so"
 [ -f "$LIB" ] || LIB="$CARGO_TARGET_DIR/release/lib${CRATE}.dylib"
-cp "$LIB" "$BUILD/${CRATE}.vpi"
-iverilog -g2012 -o "$BUILD/${CRATE}.vvp" -s "$TOP" "${HDL[@]}"
 export RUSTDV_RANDOM_SEED="${RUSTDV_RANDOM_SEED:-1}"
-vvp -M "$BUILD" -m "$CRATE" "$BUILD/${CRATE}.vvp"
+
+case "$SIM" in
+  icarus)
+    cp "$LIB" "$BUILD/${CRATE}.vpi"
+    iverilog -g2012 -o "$BUILD/${CRATE}.vvp" -s "$TOP" "${HDL[@]}"
+    vvp -M "$BUILD" -m "$CRATE" "$BUILD/${CRATE}.vvp"
+    ;;
+  verilator)
+    "$REPO_ROOT/sim/run_verilator.sh" "$LIB" "$TOP" "$BUILD/${CRATE}-verilator" "${HDL[@]}"
+    ;;
+  *)
+    echo "unknown simulator: $SIM (use icarus|verilator)" >&2
+    exit 2
+    ;;
+esac

--- a/output/regression/TESTING.md
+++ b/output/regression/TESTING.md
@@ -79,11 +79,11 @@ regression.
 
 ## Continuous integration
 
-`.github/workflows/ci.yml` runs two jobs on every push and PR: the full
-regression suite (Rust toolchain, no simulators — sim tests skip), and the
-simulator smoke tests on Icarus + Verilator. Commercial simulators can't run
-in public CI; license-holders run `sim/run_smoke.sh <sim>` or the same
-regress command locally.
+`.github/workflows/ci.yml` runs the full no-simulator regression plus a
+free-simulator matrix. Linux runs the Icarus and Verilator entries; macOS
+repeats the Verilator runtime, scheduler, DEBUG/FST, and mutation entries.
+Commercial simulators cannot run in public CI; license-holders run
+`sim/run_smoke.sh <sim>` locally.
 
 The rule of thumb: **every new piece of functionality lands together with the
 test that would catch its removal.** The pre-push hook then makes it
@@ -138,6 +138,12 @@ TinyALU's XOR to an OR, requires two testbenches to **fail**, then requires
 both to pass again on the real RTL. A scoreboard that cannot fail is not a
 scoreboard.
 
+The Verilator entries add a host-scheduler contract, the full TinyALU Rust
+testbench, selected-internal DEBUG/FST output, and the same mutation check.
+The scheduler test proves that VPI-only timers keep the model alive, the
+earlier of RTL and VPI deadlines wins, a ReadWrite VPI write settles through
+combinational RTL before ReadOnly, and final/end-of-simulation hooks run.
+
 **Compile-fail — `rustdv/framework-tests/compile-fail/`.** Claims the book
 makes about what the compiler rejects. Each case asserts its `error[E….]`
 code, not merely that the build failed; without the code a case that started
@@ -157,10 +163,10 @@ Both are properties of the runner, not quirks of these tests:
   visible: a test that follows a ReadOnly-ending test starts one step later
   than its own arithmetic suggests, so measure elapsed time between two
   `sim_time_ns()` reads rather than from an assumed start.
-- **vvp exits when its event queue empties.** A test with no clock and no
+- **A simulator exits when every relevant event queue empties.** A test with no clock and no
   pending timer that awaits `next_time_step()` will not be woken — the
   simulator quits and the rest of the regression never runs. Keep a clock or a
-  timer alive.
+  timer alive. The Verilator host considers both RTL events and VPI deadlines.
 
 ### Adding a `test.json` option
 

--- a/output/regression/tests/sim-callback-lifecycle-verilator/test.json
+++ b/output/regression/tests/sim-callback-lifecycle-verilator/test.json
@@ -1,0 +1,20 @@
+{
+  "comment": "One million ReadOnly/NextTimeStep iterations must reach an RSS plateau after fired one-shot VPI handles are released.",
+  "cmd": ["bash", "rustdv/framework-tests/run.sh"],
+  "cwd": ".",
+  "skip_if_missing": "verilator",
+  "env": {
+    "SIM": "verilator",
+    "RUSTDV_TESTCASE": "callback_stress_",
+    "RUSTDV_CALLBACK_STRESS_CYCLES": "1000000",
+    "RUSTDV_CALLBACK_STRESS_MAX_RSS_GROWTH_KIB": "16384"
+  },
+  "expect_exit": 0,
+  "timeout": 900,
+  "expect_in_output": [
+    "rustdv: found 1 test(s)",
+    "CALLBACK STRESS: cycles=1000000",
+    "callback_stress_one_shot_handles_plateau PASSED",
+    "REGRESSION: PASS"
+  ]
+}

--- a/output/regression/tests/sim-debug-verilator/run.sh
+++ b/output/regression/tests/sim-debug-verilator/run.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Prove DEBUG mode accepts selected visibility and emits a non-empty FST.
+set -euo pipefail
+cd "$(dirname "$0")/../../../.."
+
+BUILD="/tmp/rustdv-$(id -u)/verilator-debug-regression"
+SIM_BUILD_DIR="$BUILD" RUSTDV_VERILATOR_MODE=debug \
+    bash sim/run_rustdv.sh release verilator
+
+FST="$BUILD/verilator/tinyalu.fst"
+if [ ! -s "$FST" ]; then
+    echo "FST: FAIL — missing or empty $FST" >&2
+    exit 1
+fi
+echo "FST: PASS ($FST)"

--- a/output/regression/tests/sim-debug-verilator/test.json
+++ b/output/regression/tests/sim-debug-verilator/test.json
@@ -1,0 +1,9 @@
+{
+  "comment": "Verilator DEBUG policy: top ports plus the selected TinyALU internals in sim/verilator-debug.vlt, with a non-empty FST. FAST and framework visibility are covered by their own entries.",
+  "cmd": ["bash", "output/regression/tests/sim-debug-verilator/run.sh"],
+  "cwd": ".",
+  "skip_if_missing": "verilator",
+  "expect_exit": 0,
+  "timeout": 600,
+  "expect_in_output": ["REGRESSION: PASS", "FST: PASS"]
+}

--- a/output/regression/tests/sim-lint-verilator/test.json
+++ b/output/regression/tests/sim-lint-verilator/test.json
@@ -1,8 +1,8 @@
 {
-  "comment": "TinyALU lint on Verilator (full Verilator simulation arrives with rustdv). Skips on machines without verilator; runs in CI.",
+  "comment": "Self-checking TinyALU RTL smoke test on Verilator. The historical test id says lint, but this now elaborates and runs the design. Skips on machines without verilator; runs in CI.",
   "cmd": ["bash", "sim/run_smoke.sh", "verilator"],
   "cwd": ".",
   "skip_if_missing": "verilator",
   "expect_exit": 0,
-  "expect_in_output": ["LINT: PASS"]
+  "expect_in_output": ["SMOKE: PASS"]
 }

--- a/output/regression/tests/sim-mutation-verilator/test.json
+++ b/output/regression/tests/sim-mutation-verilator/test.json
@@ -1,0 +1,10 @@
+{
+  "comment": "Verilator counterpart of the TinyALU XOR-to-OR mutation test: both scoreboards must fail on corrupt RTL and pass on the real RTL. This also pins the shell verdict check until the host has a simulator-independent result API.",
+  "cmd": ["bash", "output/regression/tests/sim-mutation/mutate.sh"],
+  "cwd": ".",
+  "skip_if_missing": "verilator",
+  "env": { "SIM": "verilator" },
+  "expect_exit": 0,
+  "timeout": 900,
+  "expect_in_output": ["MUTATION: CAUGHT"]
+}

--- a/output/regression/tests/sim-mutation/mutate.sh
+++ b/output/regression/tests/sim-mutation/mutate.sh
@@ -15,13 +15,14 @@
 # Success criterion: prints "MUTATION: CAUGHT".
 set -uo pipefail
 cd "$(dirname "$0")/../../../.."       # repo root
+SIM="${SIM:-icarus}"
 # run_sim.sh cds to output/examples, so every path handed to it must be
 # absolute — a relative one would be resolved against the wrong directory.
 EXAMPLES="$PWD/output/examples"
 TIMESCALE="$EXAMPLES/sim-common/hdl/timescale.v"
 
 RUSTDV_TMP="/tmp/rustdv-$(id -u)"
-WORK="$RUSTDV_TMP/mutation"
+WORK="$RUSTDV_TMP/mutation-$SIM"
 mkdir -p "$WORK"
 
 GOOD="$EXAMPLES/sim-common/hdl/tinyalu.sv"
@@ -52,10 +53,16 @@ status=0
 for crate in "${CASES[@]}"; do
     # Separate build roots so the mutated .vvp never overwrites the good one
     # that the sim-ch* entries run.
-    out_bad=$(SIM_BUILD_DIR="$WORK/bad" bash "$EXAMPLES/sim-common/run_sim.sh" \
+    out_bad=$(SIM="$SIM" SIM_BUILD_DIR="$WORK/bad" bash "$EXAMPLES/sim-common/run_sim.sh" \
         "$crate" tinyalu "$TIMESCALE" "$BAD" 2>&1)
+    bad_status=$?
     if grep -q "REGRESSION: FAIL" <<< "$out_bad"; then
-        echo "  ok   $crate failed against the mutated RTL"
+        if [ "$SIM" = verilator ] && [ "$bad_status" -eq 0 ]; then
+            echo "  FAIL $crate printed FAIL but the Verilator wrapper returned zero" >&2
+            status=1
+        else
+            echo "  ok   $crate failed against the mutated RTL"
+        fi
     elif ! grep -q "REGRESSION:" <<< "$out_bad"; then
         # No verdict at all: the build or the simulator fell over, and
         # "it did not pass" would be the wrong thing to conclude.
@@ -69,9 +76,10 @@ for crate in "${CASES[@]}"; do
 
     # The control. Without it, a testbench that had stopped compiling would
     # "catch" every mutation.
-    out_good=$(SIM_BUILD_DIR="$WORK/good" bash "$EXAMPLES/sim-common/run_sim.sh" \
+    out_good=$(SIM="$SIM" SIM_BUILD_DIR="$WORK/good" bash "$EXAMPLES/sim-common/run_sim.sh" \
         "$crate" tinyalu "$TIMESCALE" "$GOOD" 2>&1)
-    if grep -q "REGRESSION: PASS" <<< "$out_good"; then
+    good_status=$?
+    if grep -q "REGRESSION: PASS" <<< "$out_good" && [ "$good_status" -eq 0 ]; then
         echo "  ok   $crate passed against the real RTL"
     else
         echo "  FAIL $crate did not pass against the real RTL — the run above proved nothing" >&2

--- a/output/regression/tests/sim-scheduler-verilator/test.json
+++ b/output/regression/tests/sim-scheduler-verilator/test.json
@@ -1,0 +1,22 @@
+{
+  "comment": "Verilator scheduler contract: VPI-only timers keep the run alive, phase callbacks fire in order, VPI writes are evaluated to a fixed point before ReadOnly, and start/finish complete the regression. Four-state-only signal cases remain Icarus reference tests.",
+  "cmd": ["bash", "rustdv/framework-tests/run.sh"],
+  "cwd": ".",
+  "skip_if_missing": "verilator",
+  "env": {
+    "SIM": "verilator",
+    "RUSTDV_TESTCASE": "trig_,clock_,conc_,elab_,runner_,sig_widths,sig_round_trips,sig_truncates,sig_reads,sig_missing"
+  },
+  "expect_exit": 0,
+  "timeout": 600,
+  "expect_in_output": [
+    "rustdv: found 37 test(s)",
+    "trig_timer_advances_exactly PASSED",
+    "trig_earliest_rtl_or_vpi_deadline_wins PASSED",
+    "trig_at_end_write_settles_before_read_only PASSED",
+    "trig_read_only_sees_settled_rtl PASSED",
+    "REGRESSION: PASS",
+    "RTL FINAL: PASS",
+    "END OF SIMULATION CALLBACK: PASS"
+  ]
+}

--- a/output/regression/tests/sim-tinyalu-tb-verilator/test.json
+++ b/output/regression/tests/sim-tinyalu-tb-verilator/test.json
@@ -1,0 +1,14 @@
+{
+  "comment": "The shipped TinyALU Rust testbench on Verilator FAST mode. Requires Verilator 5.050 or newer for runtime VPI loading and checks the simulator-independent verdict because vpiFinish itself exits zero after a failed regression.",
+  "cmd": ["bash", "sim/run_rustdv.sh", "release", "verilator"],
+  "cwd": ".",
+  "skip_if_missing": "verilator",
+  "expect_exit": 0,
+  "timeout": 600,
+  "expect_in_output": [
+    "REGRESSION: PASS",
+    "scoreboard: 20 compared, 0 mismatches",
+    "scoreboard: 4 compared, 0 mismatches",
+    "coverage: Add=5 And=5 Mul=5 Xor=5"
+  ]
+}

--- a/rustdv/Cargo.lock
+++ b/rustdv/Cargo.lock
@@ -65,6 +65,9 @@ dependencies = [
 [[package]]
 name = "rustdv-vpi-stubs"
 version = "0.1.0"
+dependencies = [
+ "rustdv-gpi-sys",
+]
 
 [[package]]
 name = "tinyalu_tb"

--- a/rustdv/framework-tests/hdl/probe.sv
+++ b/rustdv/framework-tests/hdl/probe.sv
@@ -18,6 +18,18 @@ module probe;
    logic [3:0]  nibble;
    logic        flag;
 
+   // Combinational path used to prove that a VPI write in ReadWrite is
+   // re-evaluated before ReadOnly callbacks observe the design.
+   logic [7:0]  comb_in;
+   wire [7:0]   comb_out = comb_in ^ 8'hA5;
+
+   // An RTL-owned delayed event used to prove the Verilator host advances to
+   // the earlier of an RTL time slot and a pending VPI deadline.
+   logic        rtl_event_request;
+   logic        rtl_event_done;
+   initial rtl_event_done = 0;
+   always @(posedge rtl_event_request) #7 rtl_event_done = 1;
+
    // Never assigned anywhere: stays X for the whole simulation, which is what
    // the X/Z tests read.
    logic        never_driven;
@@ -34,7 +46,10 @@ module probe;
    // "no object named 'byte_sig' in scope 'probe'". Reading them all into one
    // wire nobody uses keeps them alive without driving them, which is the
    // whole point of declaring them.
-   wire keep_alive = ^{byte_sig, word_sig, nibble, flag,
+   wire keep_alive = ^{byte_sig, word_sig, nibble, flag, comb_in, comb_out,
+                       rtl_event_request, rtl_event_done,
                        never_driven, never_driven_bus};
+
+   final $display("RTL FINAL: PASS");
 
 endmodule

--- a/rustdv/framework-tests/run.sh
+++ b/rustdv/framework-tests/run.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
-# Run the framework's targeted simulator tests (test-plan §3) on Icarus.
+# Run the framework's targeted simulator tests (test-plan §3).
 #
 # Usage:  framework-tests/run.sh [testcase-substring[,...]]
 #
 # With no argument every test in the crate runs. With one, RUSTDV_TESTCASE
 # selects a group by name prefix — `trig_`, `clock_`, `sig_`, `conc_`,
-# `elab_`, `runner_` — which is how the regression gets one entry per
-# mechanism off a single build.
+# `elab_`, `runner_`, `callback_stress_` — which is how the regression gets
+# one entry per mechanism off a single build.
 #
 # Success criterion: prints "REGRESSION: PASS".
 set -euo pipefail
 cd "$(dirname "$0")"
+SIM="${SIM:-icarus}"
+REPO_ROOT="$(cd ../.. && pwd)"
 
 # Scratch under one per-user root; see output/examples/sim-common/run_sim.sh
 # for why the uid is in the path.
@@ -22,14 +24,25 @@ export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$RUSTDV_TMP/target}"
 BUILD="${SIM_BUILD_DIR:-$RUSTDV_TMP/framework-tests}"; mkdir -p "$BUILD"
 LIB="$CARGO_TARGET_DIR/release/libframework_tests.so"            # Linux
 [ -f "$LIB" ] || LIB="$CARGO_TARGET_DIR/release/libframework_tests.dylib"  # macOS
-cp "$LIB" "$BUILD/framework_tests.vpi"
-
-iverilog -g2012 -o "$BUILD/probe.vvp" -s probe hdl/probe.sv
-
 export RUSTDV_RANDOM_SEED="${RUSTDV_RANDOM_SEED:-1}"
 export RUSTDV_RESULTS_XML="${RUSTDV_RESULTS_XML:-$BUILD/results.xml}"
 if [ $# -gt 0 ]; then
     export RUSTDV_TESTCASE="$1"
 fi
 
-vvp -M "$BUILD" -m framework_tests "$BUILD/probe.vvp"
+case "$SIM" in
+  icarus)
+    cp "$LIB" "$BUILD/framework_tests.vpi"
+    iverilog -g2012 -o "$BUILD/probe.vvp" -s probe hdl/probe.sv
+    vvp -M "$BUILD" -m framework_tests "$BUILD/probe.vvp"
+    ;;
+  verilator)
+    export RUSTDV_VERILATOR_MODE=framework
+    "$REPO_ROOT/sim/run_verilator.sh" "$LIB" probe "$BUILD/verilator" \
+      "$REPO_ROOT/rustdv/framework-tests/hdl/probe.sv"
+    ;;
+  *)
+    echo "unknown simulator: $SIM (use icarus|verilator)" >&2
+    exit 2
+    ;;
+esac

--- a/rustdv/framework-tests/src/callback_lifecycle.rs
+++ b/rustdv/framework-tests/src/callback_lifecycle.rs
@@ -1,0 +1,74 @@
+//! Long-running callback ownership regression for simulator-backed tests.
+
+use std::process::Command;
+
+use rustdv::prelude::*;
+
+const DEFAULT_CYCLES: u64 = 10_000;
+const DEFAULT_MAX_RSS_GROWTH_KIB: u64 = 16 * 1024;
+
+fn env_u64(name: &str, default: u64) -> Result<u64, TestError> {
+    match std::env::var(name) {
+        Ok(value) => value.parse::<u64>().map_err(|_| {
+            TestError::new(format!("{name} must be an unsigned integer, got '{value}'"))
+        }),
+        Err(std::env::VarError::NotPresent) => Ok(default),
+        Err(error) => Err(TestError::new(format!("could not read {name}: {error}"))),
+    }
+}
+
+fn rss_kib() -> Result<u64, TestError> {
+    let pid = std::process::id().to_string();
+    let output = Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid])
+        .output()
+        .map_err(|error| TestError::new(format!("could not sample simulator RSS: {error}")))?;
+    if !output.status.success() {
+        return Err(TestError::new(format!(
+            "ps failed while sampling simulator RSS: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        )));
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<u64>()
+        .map_err(|error| TestError::new(format!("could not parse simulator RSS: {error}")))
+}
+
+#[rustdv::test]
+async fn callback_stress_one_shot_handles_plateau(ctx: RustdvCtx) -> Result<(), TestError> {
+    let cycles = env_u64("RUSTDV_CALLBACK_STRESS_CYCLES", DEFAULT_CYCLES)?;
+    let max_growth = env_u64(
+        "RUSTDV_CALLBACK_STRESS_MAX_RSS_GROWTH_KIB",
+        DEFAULT_MAX_RSS_GROWTH_KIB,
+    )?;
+    check!(
+        cycles >= 10,
+        "callback stress needs at least 10 cycles, got {cycles}"
+    );
+
+    let clk = ctx.dut().signal("clk")?;
+    Clock::new(&clk, SimDuration::ns(2)).start();
+    let warmup_cycle = cycles / 10;
+    let mut warmup_rss = None;
+
+    for cycle in 1..=cycles {
+        read_only().await;
+        next_time_step().await;
+        if cycle == warmup_cycle {
+            warmup_rss = Some(rss_kib()?);
+        }
+    }
+
+    let warmup_rss = warmup_rss.expect("warm-up sample was not taken");
+    let final_rss = rss_kib()?;
+    let growth = final_rss.saturating_sub(warmup_rss);
+    rustdv::log::info(&format!(
+        "CALLBACK STRESS: cycles={cycles} warmup_rss={warmup_rss}KiB final_rss={final_rss}KiB growth={growth}KiB"
+    ));
+    check!(
+        growth <= max_growth,
+        "one-shot callback RSS grew by {growth}KiB after warm-up; limit is {max_growth}KiB"
+    );
+    Ok(())
+}

--- a/rustdv/framework-tests/src/framework_tests.rs
+++ b/rustdv/framework-tests/src/framework_tests.rs
@@ -23,7 +23,9 @@
 //! Each module prefixes its test names, and the regression selects a group
 //! with `RUSTDV_TESTCASE`. So `sim-triggers` and `sim-concurrency` are
 //! separate lines in the regression report but share one build and one
-//! elaboration.
+//! elaboration. The long `callback_stress_` group is selected only by its
+//! dedicated Verilator regression; an unfiltered manual run uses its short
+//! default cycle count.
 //!
 //! | prefix | module | what it pins down |
 //! |---|---|---|
@@ -33,6 +35,7 @@
 //! | `conc_` | [`concurrency`] | the D82 family, against real time |
 //! | `elab_` | [`elaboration`] | unconnected ports fail before the run phase |
 //! | `runner_` | [`runner`] | timeouts, `expect_error`, per-test freshness |
+//! | `callback_stress_` | [`callback_lifecycle`] | fired one-shot handles reach an RSS plateau |
 //!
 //! The DUT is `hdl/probe.sv`: a clock, signals of known widths that nothing
 //! drives, and one counter so an edge trigger has something to trigger on.
@@ -69,12 +72,13 @@ macro_rules! check {
     };
 }
 
-pub mod triggers;
+pub mod callback_lifecycle;
 pub mod clocks;
-pub mod signals;
 pub mod concurrency;
 pub mod elaboration;
 pub mod runner;
+pub mod signals;
+pub mod triggers;
 
 /// How many simulator time steps make one nanosecond, measured rather than
 /// assumed.

--- a/rustdv/framework-tests/src/triggers.rs
+++ b/rustdv/framework-tests/src/triggers.rs
@@ -195,6 +195,62 @@ async fn trig_with_timeout_inner_wins(_ctx: RustdvCtx) -> Result<(), TestError> 
     Ok(())
 }
 
+// The Verilator host owns two independent time queues: delayed RTL events and
+// VPI timers. It must always advance to the earlier deadline rather than
+// starving one queue behind the other.
+#[rustdv::test]
+async fn trig_earliest_rtl_or_vpi_deadline_wins(ctx: RustdvCtx) -> Result<(), TestError> {
+    let request = ctx.dut().signal("rtl_event_request")?;
+    let done = ctx.dut().signal("rtl_event_done")?;
+    request.set_u64_now(0);
+    request.set_u64(1);
+    read_write().await;
+
+    let t0 = sim_time_ns();
+    Timer::ns(3).await;
+    check!(sim_time_ns() - t0 == 3.0, "the earlier VPI deadline did not win");
+    check!(!done.is_high(), "the 7ns RTL event fired before the 3ns VPI timer");
+
+    let edge = with_timeout(done.rising_edge(), SimDuration::ns(5)).await;
+    check!(edge.is_ok(), "the earlier RTL event lost to a later VPI timeout");
+    check!(sim_time_ns() - t0 == 7.0, "the RTL event did not fire after 7ns");
+    Ok(())
+}
+
+// Verilator's callback regions are AtEnd -> ReadWrite -> ReadOnly. An AtEnd
+// callback may write the DUT, and the host must re-evaluate that write before
+// any ReadOnly waiter observes the combinational result.
+#[rustdv::test]
+async fn trig_at_end_write_settles_before_read_only(ctx: RustdvCtx) -> Result<(), TestError> {
+    let input = ctx.dut().signal("comb_in")?;
+    let output = ctx.dut().signal("comb_out")?;
+    input.set_u64_now(0);
+    read_write().await;
+
+    rustdv::gpi::register_at_end_of_sim_time(Box::new(move || {
+        input.set_u64_now(0x5A);
+    }))
+    .forget();
+    read_only().await;
+
+    let got = output.get_u64().unwrap_or(0);
+    check!(got == (0x5A ^ 0xA5), "ReadOnly saw {got:#x} before the AtEnd write settled");
+    Ok(())
+}
+
+// The test itself passes before simulation shutdown. The marker printed by
+// this detached callback proves the host delivered cbEndOfSimulation.
+#[rustdv::test]
+async fn trig_end_of_simulation_callback_is_delivered(
+    _ctx: RustdvCtx,
+) -> Result<(), TestError> {
+    rustdv::gpi::register_end_of_simulation(Box::new(|| {
+        println!("END OF SIMULATION CALLBACK: PASS");
+    }))
+    .forget();
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Phase triggers
 // ---------------------------------------------------------------------------
@@ -224,6 +280,23 @@ async fn trig_writes_are_scheduled_not_immediate(ctx: RustdvCtx) -> Result<(), T
     sig.set_u64_now(0x5A);
     let now = sig.get_u64().unwrap_or(0);
     check!(now == 0x5A, "set_u64_now did not take effect immediately (read {now:#x})");
+    Ok(())
+}
+
+// A VPI write made in ReadWrite must reach the RTL and settle before
+// ReadOnly.  Verilator hosts have to perform the intervening eval explicitly;
+// without it this reads the previous value even though phase callbacks fire.
+#[rustdv::test]
+async fn trig_read_only_sees_settled_rtl(ctx: RustdvCtx) -> Result<(), TestError> {
+    let input = ctx.dut().signal("comb_in")?;
+    let output = ctx.dut().signal("comb_out")?;
+
+    input.set_u64(0x3C);
+    read_write().await;
+    read_only().await;
+
+    let got = output.get_u64().unwrap_or(0);
+    check!(got == (0x3C ^ 0xA5), "ReadOnly saw comb_out={got:#x} before RTL settled");
     Ok(())
 }
 

--- a/rustdv/rustdv-gpi-sys/src/rustdv_gpi_sys.rs
+++ b/rustdv/rustdv-gpi-sys/src/rustdv_gpi_sys.rs
@@ -114,6 +114,7 @@ pub const cbAfterDelay: PLI_INT32 = 9;
 pub const cbEndOfCompile: PLI_INT32 = 10;
 pub const cbStartOfSimulation: PLI_INT32 = 11;
 pub const cbEndOfSimulation: PLI_INT32 = 12;
+pub const cbAtEndOfSimTime: PLI_INT32 = 31;
 
 // ---------------------------------------------------------------------------
 // Structs
@@ -138,7 +139,7 @@ pub union u_vpi_value_union {
     pub integer: PLI_INT32,
     pub real: f64,
     pub time: *mut t_vpi_time,
-    pub vector: *mut c_void,
+    pub vector: *mut t_vpi_vecval,
     pub strength: *mut c_void,
     pub misc: *mut PLI_BYTE8,
 }
@@ -148,6 +149,15 @@ pub union u_vpi_value_union {
 pub struct t_vpi_value {
     pub format: PLI_INT32,
     pub value: u_vpi_value_union,
+}
+
+/// One 32-bit word of a four-state VPI vector. `aval` carries the value bits;
+/// a set bit in `bval` marks the corresponding bit as X/Z.
+#[repr(C)]
+#[derive(Clone, Copy, Default)]
+pub struct t_vpi_vecval {
+    pub aval: PLI_UINT32,
+    pub bval: PLI_UINT32,
 }
 
 #[repr(C)]

--- a/rustdv/rustdv-gpi/src/rustdv_gpi.rs
+++ b/rustdv/rustdv-gpi/src/rustdv_gpi.rs
@@ -5,8 +5,10 @@
 //!
 //! 1. Handles are opaque and non-null; fallible acquisition is `Result`.
 //! 2. Object-handle lifetime = simulation lifetime (freely `Copy`able IDs).
-//!    Callback handles invalidate on removal/fire — modeled by RAII
-//!    ([`CallbackHandle`]): dropping an unfired handle removes the callback.
+//!    Callback registrations are modeled by RAII ([`CallbackHandle`]):
+//!    dropping a live handle removes it, and fired one-shots remove themselves
+//!    from inside the trampoline while both supported simulators still accept
+//!    the registration handle.
 //! 3. Strings are copied at the boundary, every call.
 //! 4. No unwinding across FFI: every trampoline wraps the closure in
 //!    `catch_unwind`; panics are routed to the panic sink.
@@ -123,7 +125,11 @@ impl AnyHandle {
             sys::vpiNet | sys::vpiReg | sys::vpiIntegerVar | sys::vpiPort | sys::vpiMemory
             | sys::vpiLongIntVar | sys::vpiShortIntVar | sys::vpiIntVar | sys::vpiByteVar
             | sys::vpiEnumVar | sys::vpiBitVar => {
-                AnyHandle::Logic(LogicHandle { h })
+                // Signal width is immutable for the lifetime of a VPI
+                // object. Cache it at discovery so every value read/write
+                // does not pay for another vpi_get(vpiSize) crossing.
+                let width = h.get(sys::vpiSize).max(0) as u32;
+                AnyHandle::Logic(LogicHandle { h, width })
             }
             _ => AnyHandle::Other(h),
         }
@@ -232,6 +238,7 @@ impl HierarchyHandle {
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct LogicHandle {
     h: ObjHandle,
+    width: u32,
 }
 
 impl LogicHandle {
@@ -242,7 +249,7 @@ impl LogicHandle {
         self.h.get_str(sys::vpiFullName)
     }
     pub fn size(&self) -> u32 {
-        self.h.get(sys::vpiSize).max(0) as u32
+        self.width
     }
 
     /// Current value as a binary string, e.g. "0101", "xxxx".
@@ -270,16 +277,46 @@ impl LogicHandle {
     /// Current value as u64; `Err` if any bit is x/z (design-doc §0.6:
     /// conversion failures are Results, not exceptions).
     pub fn get_u64(&self) -> Result<u64, ValueError> {
-        let s = self.get_binstr();
-        let mut v: u64 = 0;
-        for c in s.chars() {
-            match c {
-                '0' => v <<= 1,
-                '1' => v = (v << 1) | 1,
-                _ => return Err(ValueError::FourState(s)),
-            }
+        let width = self.size().max(1);
+        if width > 64 {
+            return Err(ValueError::Width {
+                want: width,
+                have: 64,
+            });
         }
-        Ok(v)
+        let mut val = sys::t_vpi_value {
+            format: sys::vpiVectorVal,
+            value: sys::u_vpi_value_union {
+                vector: std::ptr::null_mut(),
+            },
+        };
+        unsafe {
+            sys::vpi_get_value(self.h.0, &mut val);
+            let words = val.value.vector;
+            if words.is_null() {
+                return Ok(0);
+            }
+            let word_count = width.div_ceil(32) as usize;
+            let mut result = 0u64;
+            for index in 0..word_count {
+                let word = *words.add(index);
+                let used_bits = if index + 1 == word_count && !width.is_multiple_of(32) {
+                    width % 32
+                } else {
+                    32
+                };
+                let mask = if used_bits == 32 {
+                    u32::MAX
+                } else {
+                    (1u32 << used_bits) - 1
+                };
+                if word.bval & mask != 0 {
+                    return Err(ValueError::FourState(self.get_binstr()));
+                }
+                result |= ((word.aval & mask) as u64) << (index * 32);
+            }
+            Ok(result)
+        }
     }
 
     fn put_binstr_flags(&self, bin: &str, flags: i32) {
@@ -293,16 +330,49 @@ impl LogicHandle {
         }
     }
 
+    fn put_vector_words(&self, words: &mut [sys::t_vpi_vecval]) {
+        let mut val = sys::t_vpi_value {
+            format: sys::vpiVectorVal,
+            value: sys::u_vpi_value_union {
+                vector: words.as_mut_ptr(),
+            },
+        };
+        unsafe {
+            sys::vpi_put_value(self.h.0, &mut val, std::ptr::null_mut(), sys::vpiNoDelay);
+        }
+    }
+
     /// Immediate (NoDelay) write of an integer value, zero-extended /
     /// truncated to the signal width. This is the "setimmediatevalue"
     /// analog; scheduled writes are layered above (design-doc §4.1(4)).
     pub fn set_u64_now(&self, v: u64) {
-        let w = self.size().max(1) as usize;
-        let mut s = String::with_capacity(w);
-        for i in (0..w).rev() {
-            s.push(if (v >> i) & 1 == 1 { '1' } else { '0' });
+        let width = self.size().max(1);
+        let word_count = width.div_ceil(32) as usize;
+        let mut words = if word_count <= 2 {
+            let words = [
+                sys::t_vpi_vecval {
+                    aval: v as u32,
+                    bval: 0,
+                },
+                sys::t_vpi_vecval {
+                    aval: (v >> 32) as u32,
+                    bval: 0,
+                },
+            ];
+            words[..word_count].to_vec()
+        } else {
+            let mut words = vec![sys::t_vpi_vecval::default(); word_count];
+            words[0].aval = v as u32;
+            words[1].aval = (v >> 32) as u32;
+            words
+        };
+        if !width.is_multiple_of(32) {
+            let mask = (1u32 << (width % 32)) - 1;
+            let last = words.last_mut().expect("positive width has a vector word");
+            last.aval &= mask;
+            last.bval &= mask;
         }
-        self.put_binstr_flags(&s, sys::vpiNoDelay);
+        self.put_vector_words(&mut words);
     }
 
     /// Immediate write of a 4-state value.
@@ -413,6 +483,11 @@ enum CbKind {
 
 struct CbShared {
     kind: CbKind,
+    /// Registration handle returned by vpi_register_cb. One-shots remove it
+    /// from inside the trampoline, while it is valid on both supported
+    /// simulators: Icarus reaps the active callback after it returns and
+    /// Verilator releases its separately-owned handle object immediately.
+    vpi_h: Cell<sys::vpiHandle>,
     /// True once the C-side Rc reference has been reclaimed (fired one-shot
     /// or removed callback). Guards against double-free.
     released: Cell<bool>,
@@ -426,23 +501,27 @@ struct CbShared {
 pub struct CallbackHandle {
     shared: Rc<CbShared>,
     raw: *const CbShared,
-    vpi_h: sys::vpiHandle,
+    detached: bool,
 }
 
 impl CallbackHandle {
-    /// Detach: let the callback live for the rest of the simulation
-    /// (recurring singletons like the phase hub).
-    pub fn forget(self) {
-        std::mem::forget(self);
+    /// Detach Rust ownership without leaking it. A detached one-shot keeps its
+    /// C-side reference until it fires and then self-cleans; a detached
+    /// recurring callback lives for the rest of the simulation.
+    pub fn forget(mut self) {
+        self.detached = true;
     }
 }
 
 impl Drop for CallbackHandle {
     fn drop(&mut self) {
+        if self.detached {
+            return;
+        }
         if !self.shared.released.get() {
             self.shared.released.set(true);
             unsafe {
-                sys::vpi_remove_cb(self.vpi_h);
+                sys::vpi_remove_cb(self.shared.vpi_h.get());
                 // Reclaim the C-side reference.
                 drop(Rc::from_raw(self.raw));
             }
@@ -465,6 +544,12 @@ extern "C" fn trampoline(cb: *mut sys::t_cb_data) -> i32 {
                 if !shared.released.get() {
                     shared.released.set(true);
                     let f = shared.once.borrow_mut().take();
+                    // The returned callback handle has different post-fire
+                    // ownership across simulators. Remove it while the active
+                    // callback is still valid on both: Icarus marks it for
+                    // self-reaping, while Verilator deletes the retained
+                    // VerilatedVpioReasonCb handle.
+                    sys::vpi_remove_cb(shared.vpi_h.get());
                     // Reclaim the C-side reference before running user code.
                     drop(Rc::from_raw(ud));
                     if let Some(f) = f {
@@ -498,6 +583,7 @@ fn register(
 ) -> CallbackHandle {
     let shared = Rc::new(CbShared {
         kind,
+        vpi_h: Cell::new(std::ptr::null_mut()),
         released: Cell::new(false),
         once: RefCell::new(once),
         repeat: RefCell::new(repeat),
@@ -524,7 +610,8 @@ fn register(
     };
     let vpi_h = unsafe { sys::vpi_register_cb(&mut cb) };
     assert!(!vpi_h.is_null(), "vpi_register_cb failed (reason {reason})");
-    CallbackHandle { shared, raw, vpi_h }
+    shared.vpi_h.set(vpi_h);
+    CallbackHandle { shared, raw, detached: false }
 }
 
 fn simtime(steps: u64) -> sys::t_vpi_time {
@@ -569,6 +656,18 @@ pub fn register_next_sim_time(f: Box<dyn FnOnce()>) -> CallbackHandle {
     register(CbKind::OneShot, Some(f), None, sys::cbNextSimTime, std::ptr::null_mut(), None)
 }
 
+/// One-shot callback at the end of the current simulation time step.
+pub fn register_at_end_of_sim_time(f: Box<dyn FnOnce()>) -> CallbackHandle {
+    register(
+        CbKind::OneShot,
+        Some(f),
+        None,
+        sys::cbAtEndOfSimTime,
+        std::ptr::null_mut(),
+        Some(simtime(sim_time_steps())),
+    )
+}
+
 /// One-shot callback at start of simulation (the bootstrap hook).
 pub fn register_start_of_simulation(f: Box<dyn FnOnce()>) -> CallbackHandle {
     register(CbKind::OneShot, Some(f), None, sys::cbStartOfSimulation, std::ptr::null_mut(), None)
@@ -577,4 +676,138 @@ pub fn register_start_of_simulation(f: Box<dyn FnOnce()>) -> CallbackHandle {
 /// One-shot callback at end of simulation.
 pub fn register_end_of_simulation(f: Box<dyn FnOnce()>) -> CallbackHandle {
     register(CbKind::OneShot, Some(f), None, sys::cbEndOfSimulation, std::ptr::null_mut(), None)
+}
+
+#[cfg(test)]
+mod callback_tests {
+    use super::*;
+    use std::cell::Cell;
+    use std::rc::Rc;
+
+    #[test]
+    fn fired_one_shot_releases_its_vpi_handle() {
+        rustdv_vpi_stubs::reset_callbacks();
+        let fired = Rc::new(Cell::new(false));
+        let fired_in_callback = fired.clone();
+        let handle = register_timer(1, Box::new(move || fired_in_callback.set(true)));
+
+        assert_eq!(rustdv_vpi_stubs::live_callback_handles(), 1);
+        rustdv_vpi_stubs::fire_next_callback();
+        assert!(fired.get());
+        drop(handle);
+
+        assert_eq!(rustdv_vpi_stubs::live_callback_handles(), 0);
+        rustdv_vpi_stubs::reset_callbacks();
+    }
+
+    #[test]
+    fn detached_one_shot_releases_shared_state_after_firing() {
+        rustdv_vpi_stubs::reset_callbacks();
+        let handle = register_timer(1, Box::new(|| {}));
+        let shared = Rc::downgrade(&handle.shared);
+
+        handle.forget();
+        assert!(shared.upgrade().is_some());
+        rustdv_vpi_stubs::fire_next_callback();
+
+        assert_eq!(rustdv_vpi_stubs::live_callback_handles(), 0);
+        assert!(shared.upgrade().is_none());
+        rustdv_vpi_stubs::reset_callbacks();
+    }
+
+    #[test]
+    fn callback_stub_refuses_to_reset_a_live_handle() {
+        rustdv_vpi_stubs::reset_callbacks();
+        let handle = register_timer(1, Box::new(|| {}));
+
+        let reset = catch_unwind(AssertUnwindSafe(rustdv_vpi_stubs::reset_callbacks));
+        assert!(reset.is_err());
+
+        drop(handle);
+        rustdv_vpi_stubs::reset_callbacks();
+    }
+}
+
+#[cfg(test)]
+mod handle_tests {
+    use super::*;
+
+    fn make_signal(width: i32, words: &[sys::t_vpi_vecval], binstr: &str) -> LogicHandle {
+        rustdv_vpi_stubs::configure_signal(width, words, binstr);
+        let raw = 1usize as sys::vpiHandle;
+        let AnyHandle::Logic(signal) = AnyHandle::classify(ObjHandle(raw)) else {
+            panic!("stub object was not classified as a signal");
+        };
+        signal
+    }
+
+    #[test]
+    fn signal_width_is_cached_when_the_handle_is_classified() {
+        rustdv_vpi_stubs::reset_property_gets();
+        let signal = make_signal(37, &[sys::t_vpi_vecval::default(); 2], &"0".repeat(37));
+
+        assert_eq!(signal.size(), 37);
+        assert_eq!(signal.size(), 37);
+        assert_eq!(rustdv_vpi_stubs::property_get_count(sys::vpiType), 1);
+        assert_eq!(rustdv_vpi_stubs::property_get_count(sys::vpiSize), 1);
+        rustdv_vpi_stubs::reset_property_gets();
+    }
+
+    #[test]
+    fn vector_read_uses_vpi_word_order_and_masks_unused_bits() {
+        let signal = make_signal(
+            37,
+            &[
+                sys::t_vpi_vecval {
+                    aval: 0x89ab_cdef,
+                    bval: 0,
+                },
+                sys::t_vpi_vecval {
+                    aval: 0xffff_fff5,
+                    bval: 0xffff_ffe0,
+                },
+            ],
+            "101011001101010111100110111101111",
+        );
+
+        assert_eq!(signal.get_u64(), Ok(0x0000_0015_89ab_cdef));
+    }
+
+    #[test]
+    fn vector_read_reports_xz_in_used_bits() {
+        let signal = make_signal(
+            8,
+            &[sys::t_vpi_vecval {
+                aval: 0x5a,
+                bval: 0x04,
+            }],
+            "01011x10",
+        );
+
+        assert_eq!(
+            signal.get_u64(),
+            Err(ValueError::FourState("01011x10".to_owned()))
+        );
+    }
+
+    #[test]
+    fn vector_write_truncates_and_zero_extends_to_signal_width() {
+        let signal = make_signal(37, &[sys::t_vpi_vecval::default(); 2], &"0".repeat(37));
+        signal.set_u64_now(0xffff_fff5_89ab_cdef);
+        let words = rustdv_vpi_stubs::last_put_vector();
+
+        assert_eq!(words.len(), 2);
+        assert_eq!(words[0].aval, 0x89ab_cdef);
+        assert_eq!(words[1].aval, 0x15);
+        assert_eq!(words[0].bval, 0);
+        assert_eq!(words[1].bval, 0);
+
+        let wide = make_signal(70, &[sys::t_vpi_vecval::default(); 3], &"0".repeat(70));
+        wide.set_u64_now(0x0123_4567_89ab_cdef);
+        let words = rustdv_vpi_stubs::last_put_vector();
+        assert_eq!(words.len(), 3);
+        assert_eq!(words[0].aval, 0x89ab_cdef);
+        assert_eq!(words[1].aval, 0x0123_4567);
+        assert_eq!(words[2].aval, 0);
+    }
 }

--- a/rustdv/rustdv-sim/src/handle.rs
+++ b/rustdv/rustdv-sim/src/handle.rs
@@ -120,10 +120,10 @@ impl LogicHandle {
     }
     /// Convenience for 1-bit signals: true iff the value is 1.
     pub fn is_high(&self) -> bool {
-        self.raw.get_binstr() == "1"
+        self.size() == 1 && self.raw.get_u64() == Ok(1)
     }
     pub fn is_low(&self) -> bool {
-        self.raw.get_binstr() == "0"
+        self.size() == 1 && self.raw.get_u64() == Ok(0)
     }
 
     // ---- write: scheduled (applied at next ReadWrite phase, row 22) ----

--- a/rustdv/rustdv-sim/src/triggers.rs
+++ b/rustdv/rustdv-sim/src/triggers.rs
@@ -146,8 +146,8 @@ impl Future for Edge {
                         }
                         let hit = match kind {
                             EdgeKind::AnyChange => true,
-                            EdgeKind::Rising => sig.get_binstr() == "1",
-                            EdgeKind::Falling => sig.get_binstr() == "0",
+                            EdgeKind::Rising => sig.size() == 1 && sig.get_u64() == Ok(1),
+                            EdgeKind::Falling => sig.size() == 1 && sig.get_u64() == Ok(0),
                         };
                         if hit {
                             sh2.fire();

--- a/rustdv/rustdv-vpi-stubs/Cargo.toml
+++ b/rustdv/rustdv-vpi-stubs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rustdv-vpi-stubs"
 version = "0.1.0"
 edition = "2021"
-description = "Panicking vpi_* symbol definitions for cargo-test executables. Dev-dependency only — never linked into the simulator-loaded cdylib, where the real symbols come from the simulator."
+description = "VPI symbol definitions and callback test double for cargo-test executables. Dev-dependency only — never linked into simulator-loaded cdylibs."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rustdv/rustdv"
 
@@ -11,3 +11,4 @@ repository = "https://github.com/rustdv/rustdv"
 path = "src/rustdv_vpi_stubs.rs"
 
 [dependencies]
+rustdv-gpi-sys = { path = "../rustdv-gpi-sys", version = "0.1.0" }

--- a/rustdv/rustdv-vpi-stubs/src/rustdv_vpi_stubs.rs
+++ b/rustdv/rustdv-vpi-stubs/src/rustdv_vpi_stubs.rs
@@ -14,12 +14,149 @@
 //! The `.vpi` module never links this crate; there the real symbols come
 //! from the simulator process (vvp) at load time.
 //!
-//! Signatures only need matching *names* for the linker; none of these may
-//! ever be called (variadics are deliberately simplified).
+//! Most entry points panic when called. Callback registration is the one
+//! exception: its small test double models a simulator that removes a fired
+//! one-shot from its schedule while retaining the returned handle. That is
+//! Verilator's ownership contract and lets `rustdv-gpi` test callback cleanup
+//! without loading a simulator. Variadics remain deliberately simplified.
 
 #![allow(non_snake_case, clippy::missing_safety_doc)]
 
+use std::cell::RefCell;
+use std::ffi::{CStr, CString};
 use std::os::raw::c_void;
+
+use rustdv_gpi_sys::{
+    t_cb_data, t_vpi_value, t_vpi_vecval, vpiBinStrVal, vpiHandle, vpiNet, vpiNoDelay,
+    vpiSize, vpiType, vpiVectorVal,
+};
+
+struct StubCallback {
+    data: t_cb_data,
+    scheduled: bool,
+    handle_live: bool,
+}
+
+struct StubSignal {
+    width: i32,
+    words: Vec<t_vpi_vecval>,
+    binstr: CString,
+    last_put: Vec<t_vpi_vecval>,
+}
+
+impl Default for StubSignal {
+    fn default() -> Self {
+        Self {
+            width: 37,
+            words: vec![t_vpi_vecval::default(); 2],
+            binstr: CString::new("0".repeat(37)).expect("static binary string contains no NUL"),
+            last_put: Vec::new(),
+        }
+    }
+}
+
+thread_local! {
+    static CALLBACKS: RefCell<Vec<*mut StubCallback>> = const { RefCell::new(Vec::new()) };
+    static PROPERTY_GETS: RefCell<Vec<i32>> = const { RefCell::new(Vec::new()) };
+    static SIGNAL: RefCell<StubSignal> = RefCell::new(StubSignal::default());
+}
+
+/// Configure the signal value returned by the unit-test VPI double.
+pub fn configure_signal(width: i32, words: &[t_vpi_vecval], binstr: &str) {
+    assert!(width > 0, "stub signal width must be positive");
+    let word_count = (width as usize).div_ceil(32);
+    assert!(
+        words.len() >= word_count,
+        "stub signal needs {word_count} vector word(s), got {}",
+        words.len()
+    );
+    SIGNAL.with(|signal| {
+        *signal.borrow_mut() = StubSignal {
+            width,
+            words: words[..word_count].to_vec(),
+            binstr: CString::new(binstr).expect("stub binary string contains NUL"),
+            last_put: Vec::new(),
+        };
+    });
+}
+
+/// Return the vector words most recently written by `vpi_put_value`.
+pub fn last_put_vector() -> Vec<t_vpi_vecval> {
+    SIGNAL.with(|signal| signal.borrow().last_put.clone())
+}
+
+/// Clear property-query counters for the calling test thread.
+pub fn reset_property_gets() {
+    PROPERTY_GETS.with(|gets| gets.borrow_mut().clear());
+}
+
+/// Number of times a VPI property was queried on the calling test thread.
+pub fn property_get_count(property: i32) -> usize {
+    PROPERTY_GETS.with(|gets| {
+        gets.borrow()
+            .iter()
+            .filter(|queried| **queried == property)
+            .count()
+    })
+}
+
+/// Remove all callback test-double state for the calling test thread.
+pub fn reset_callbacks() {
+    CALLBACKS.with(|callbacks| {
+        let mut callbacks = callbacks.borrow_mut();
+        let live = callbacks
+            .iter()
+            .filter(|callback| unsafe { (***callback).handle_live })
+            .count();
+        assert_eq!(
+            live, 0,
+            "cannot reset callback test state while {live} handle(s) are live"
+        );
+        for callback in callbacks.drain(..) {
+            unsafe {
+                drop(Box::from_raw(callback));
+            }
+        }
+    });
+}
+
+/// Fire the next scheduled callback, retaining its returned VPI handle.
+pub fn fire_next_callback() {
+    CALLBACKS.with(|callbacks| {
+        let callbacks = callbacks.borrow();
+        let callback = callbacks
+            .iter()
+            .copied()
+            .find(|callback| unsafe { (**callback).scheduled })
+            .expect("no scheduled callback to fire");
+        unsafe {
+            (*callback).scheduled = false;
+            let mut data = t_cb_data {
+                reason: (*callback).data.reason,
+                cb_rtn: (*callback).data.cb_rtn,
+                obj: (*callback).data.obj,
+                time: (*callback).data.time,
+                value: (*callback).data.value,
+                index: (*callback).data.index,
+                user_data: (*callback).data.user_data,
+            };
+            if let Some(callback_fn) = data.cb_rtn {
+                callback_fn(&mut data);
+            }
+        }
+    });
+}
+
+/// Number of callback handles not yet released on the calling test thread.
+pub fn live_callback_handles() -> usize {
+    CALLBACKS.with(|callbacks| {
+        callbacks
+            .borrow()
+            .iter()
+            .filter(|callback| unsafe { (***callback).handle_live })
+            .count()
+    })
+}
 
 macro_rules! stub {
     ($($name:ident ( $($arg:ident : $ty:ty),* ) -> $ret:ty;)*) => {
@@ -40,14 +177,105 @@ stub! {
     vpi_handle_by_index(a: *mut c_void, b: i32) -> *mut c_void;
     vpi_iterate(a: i32, b: *mut c_void) -> *mut c_void;
     vpi_scan(a: *mut c_void) -> *mut c_void;
-    vpi_get(a: i32, b: *mut c_void) -> i32;
     vpi_get_str(a: i32, b: *mut c_void) -> *mut i8;
-    vpi_get_value(a: *mut c_void, b: *mut c_void) -> ();
-    vpi_put_value(a: *mut c_void, b: *mut c_void, c: *mut c_void, d: i32) -> *mut c_void;
     vpi_get_time(a: *mut c_void, b: *mut c_void) -> ();
-    vpi_register_cb(a: *mut c_void) -> *mut c_void;
-    vpi_remove_cb(a: *mut c_void) -> i32;
     vpi_free_object(a: *mut c_void) -> i32;
     vpi_control(a: i32) -> i32;
     vpi_printf(a: *const i8) -> i32;
+}
+
+#[no_mangle]
+pub extern "C" fn vpi_get(property: i32, _handle: *mut c_void) -> i32 {
+    PROPERTY_GETS.with(|gets| gets.borrow_mut().push(property));
+    if property == vpiType {
+        vpiNet
+    } else if property == vpiSize {
+        SIGNAL.with(|signal| signal.borrow().width)
+    } else {
+        panic!("unsupported vpi_get property {property} in test stub")
+    }
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn vpi_get_value(_handle: vpiHandle, value: *mut t_vpi_value) {
+    assert!(!value.is_null(), "vpi_get_value called with null value");
+    SIGNAL.with(|signal| {
+        let signal = signal.borrow();
+        let value = unsafe { &mut *value };
+        match value.format {
+            format if format == vpiVectorVal => {
+                value.value.vector = signal.words.as_ptr().cast_mut();
+            }
+            format if format == vpiBinStrVal => {
+                value.value.str_ = signal.binstr.as_ptr().cast_mut();
+            }
+            format => panic!("unsupported vpi_get_value format {format} in test stub"),
+        }
+    });
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn vpi_put_value(
+    handle: vpiHandle,
+    value: *mut t_vpi_value,
+    _time: *mut rustdv_gpi_sys::t_vpi_time,
+    flags: i32,
+) -> vpiHandle {
+    assert!(!value.is_null(), "vpi_put_value called with null value");
+    assert_eq!(flags, vpiNoDelay, "test stub only supports immediate writes");
+    SIGNAL.with(|signal| {
+        let mut signal = signal.borrow_mut();
+        let value = unsafe { &mut *value };
+        match value.format {
+            format if format == vpiVectorVal => {
+                let word_count = (signal.width as usize).div_ceil(32);
+                let words = unsafe { std::slice::from_raw_parts(value.value.vector, word_count) };
+                signal.last_put = words.to_vec();
+            }
+            format if format == vpiBinStrVal => {
+                let text = unsafe { CStr::from_ptr(value.value.str_) };
+                signal.binstr = CString::new(text.to_bytes())
+                    .expect("written stub binary string contains NUL");
+            }
+            format => panic!("unsupported vpi_put_value format {format} in test stub"),
+        }
+    });
+    handle
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn vpi_register_cb(data: *mut t_cb_data) -> vpiHandle {
+    assert!(!data.is_null(), "vpi_register_cb called with null data");
+    let callback = Box::new(StubCallback {
+        data: unsafe {
+            t_cb_data {
+                reason: (*data).reason,
+                cb_rtn: (*data).cb_rtn,
+                obj: (*data).obj,
+                time: (*data).time,
+                value: (*data).value,
+                index: (*data).index,
+                user_data: (*data).user_data,
+            }
+        },
+        scheduled: true,
+        handle_live: true,
+    });
+    let callback = Box::into_raw(callback);
+    CALLBACKS.with(|callbacks| callbacks.borrow_mut().push(callback));
+    callback.cast::<c_void>()
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn vpi_remove_cb(handle: vpiHandle) -> i32 {
+    assert!(!handle.is_null(), "vpi_remove_cb called with null handle");
+    let callback = handle.cast::<StubCallback>();
+    unsafe {
+        if !(*callback).handle_live {
+            return 0;
+        }
+        (*callback).scheduled = false;
+        (*callback).handle_live = false;
+    }
+    1
 }

--- a/rustdv/tinyalu_tb/README.md
+++ b/rustdv/tinyalu_tb/README.md
@@ -8,6 +8,7 @@ Run with:
 
 ```
 sim/run_rustdv.sh          # or: sim/run_rustdv.sh release
+sim/run_rustdv.sh release verilator
 ```
 
 Its files are `tinyalu_tb.rs` (crate root — there is no `lib.rs`, D29), `env.rs`,
@@ -19,7 +20,7 @@ operation covered.
 
 ## Transcript
 
-Verbatim from `sim/run_rustdv.sh release`, `RUSTDV_RANDOM_SEED=1`, Linux/Icarus,
+Verbatim from `sim/run_rustdv.sh release icarus`, `RUSTDV_RANDOM_SEED=1`, Linux/Icarus,
 2026-07-30. This is the block the Interlude and ch40 both draw from; the cargo
 build lines above the first `0.00ns` are omitted.
 

--- a/sim/README.md
+++ b/sim/README.md
@@ -1,26 +1,29 @@
 # Simulator scaffold
 
-The TinyALU DUT and a smoke test proving the simulator toolchain works.
-This is groundwork for **rustdv** — the book's Rust testbench framework —
-which will drive this same DUT from Rust. Until then, the smoke test keeps
-the simulator path exercised in CI so it can't rot.
+The TinyALU DUT, the shared Verilator host, and smoke/regression entry points.
+Both free simulators are exercised in CI so the native VPI loading path cannot
+rot unnoticed.
 
 ## Files
 
-- `hdl/tinyalu.sv` — the TinyALU, copied unmodified from the pyuvm project
+- `hdl/tinyalu.sv` — the TinyALU derived from the pyuvm project
   (`reference/pyuvm-master/examples/TinyALU/hdl/verilog/tinyalu.sv`,
-  Apache-2.0, © Ray Salemi). Single-cycle ADD/AND/XOR, three-cycle MUL,
-  start/done handshake.
+  Apache-2.0, © Ray Salemi). Its self-generated clock is exposed as a
+  read-only top-level port so a FAST VPI testbench needs no internal visibility.
 - `tb/smoke_tb.sv` — minimal self-checking testbench: five operations,
   prints `SMOKE: PASS` on success.
-- `run_smoke.sh` — simulator selector.
+- `run_smoke.sh` — HDL-only simulator selector.
+- `run_rustdv.sh` — builds and runs the Rust TinyALU testbench.
+- `run_verilator.sh` / `verilator_main.cpp` — shared Verilator build wrapper
+  and correctness-critical event loop.
+- `verilator-debug.vlt` — TinyALU's deliberately selected DEBUG internals.
 
 ## Running
 
 | Simulator | Command | Notes |
 |---|---|---|
 | Icarus Verilog | `sim/run_smoke.sh icarus` | free; runs in CI |
-| Verilator | `sim/run_smoke.sh verilator` | free; lint-only for now, runs in CI |
+| Verilator | `sim/run_smoke.sh verilator` | free; runs the self-checking RTL smoke test in CI |
 | Synopsys VCS | `sim/run_smoke.sh vcs` | needs license; run locally |
 | Siemens Questa | `sim/run_smoke.sh questa` | needs license; run locally |
 | Cadence Xcelium | `sim/run_smoke.sh xcelium` | needs license; run locally |
@@ -28,6 +31,46 @@ the simulator path exercised in CI so it can't rot.
 The same tests run through the regression system
 (`output/regression/regress.py --suite custom --filter sim`) and skip
 automatically on machines without the simulator installed.
+
+Run the Rust testbench with either backend:
+
+```sh
+sim/run_rustdv.sh release icarus
+sim/run_rustdv.sh release verilator
+RUSTDV_VERILATOR_MODE=debug sim/run_rustdv.sh release verilator
+```
+
+The last command writes an FST under `/tmp/rustdv-$(id -u)/`. FAST exposes
+only top-level ports; DEBUG adds the signals in a Verilator control file; the
+small framework probe alone uses full visibility. Verilator 5.050 or newer is
+required for runtime VPI library loading.
+
+Useful Verilator controls are:
+
+| Variable | Values | Purpose |
+|---|---|---|
+| `RUSTDV_VERILATOR_MODE` | `fast`, `debug`, `framework` | visibility and tracing policy |
+| `RUSTDV_VERILATOR_CONTROL_FILE` | path to `.vlt` | selected DEBUG internals |
+| `RUSTDV_FST` | output path | DEBUG waveform location |
+| `RUSTDV_VERILATOR_OPT` | `default`, `o3` | generated-model optimization |
+| `RUSTDV_VERILATOR_THREADS` | `1`, `2`, `4` | Verilated model threads |
+| `RUSTDV_VERILATOR_NATIVE` | `0`, `1` | opt in to `-march=native` |
+| `RUSTDV_VERILATOR_PROGRESS_SECONDS` | positive seconds | optional scheduler progress |
+
+For a long local functional run, enable the same runtime-oriented build knobs
+used during performance work (native code is intentionally opt-in because the
+resulting executable is host-specific):
+
+```sh
+RUSTDV_VERILATOR_OPT=o3 \
+RUSTDV_VERILATOR_NATIVE=1 \
+RUSTDV_VERILATOR_THREADS=2 \
+sim/run_rustdv.sh release verilator
+```
+
+Verilator is a two-state simulator; use Icarus for X/Z behavior and exact book
+transcripts. The shared host is correctness-critical: it advances to the
+earliest RTL event or VPI deadline and settles VPI writes before ReadOnly.
 
 Commercial-simulator invocations are the standard ones but **untested here**
 — public CI cannot hold EDA licenses. If you have a license and the command

--- a/sim/hdl/tinyalu.sv
+++ b/sim/hdl/tinyalu.sv
@@ -3,6 +3,7 @@ module tinyalu (input [7:0] A,
 		input [2:0] op,
 		input reset_n,
 		input start,
+		output bit clk,
 		output done,
 		output [15:0] result);
 
@@ -10,7 +11,6 @@ module tinyalu (input [7:0] A,
    // it must on an emulator, where a software-driven clock would cross the
    // hardware boundary on every edge. rustdv generates no clock; BFMs only
    // ever wait on edges. 10ns period at the 1ns/1ns timescale.
-   bit clk;
    initial clk = 0;
    always #5 clk = ~clk;
 

--- a/sim/run_rustdv.sh
+++ b/sim/run_rustdv.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
-# Build the rustdv TinyALU testbench and run it on Icarus Verilog.
+# Build the rustdv TinyALU testbench and run it on Icarus or Verilator.
 #
-# Usage:  sim/run_rustdv.sh [debug|release]     (default: release)
+# Usage:  sim/run_rustdv.sh [debug|release] [icarus|verilator]
+#         SIM=verilator sim/run_rustdv.sh release
 #
-# Flow (design-doc §7.4, VPI-module variant):
+# Icarus flow (design-doc §7.4, VPI-module variant):
 #   cargo build (cdylib) -> copy as build/tinyalu_tb.vpi
 #   iverilog the DUT (no Verilog testbench: rustdv drives the top module)
 #   vvp -M build -m tinyalu_tb  -> the VPI module bootstraps the regression
 #
-# Success criterion: prints "REGRESSION: PASS".
+# Verilator uses sim/verilator_main.cpp and runtime VPI loading. Both flows
+# require a parsed "REGRESSION: PASS" verdict.
 set -euo pipefail
 cd "$(dirname "$0")"
 
 PROFILE="${1:-release}"
+SIM="${2:-${SIM:-icarus}}"
 REPO_ROOT="$(cd .. && pwd)"
 
 # Build outside the (possibly mounted) repo for speed; see STATUS.md.
@@ -39,12 +42,25 @@ esac
 PROFDIR="$( [ "$PROFILE" = release ] && echo release || echo debug )"
 LIB="$CARGO_TARGET_DIR/$PROFDIR/libtinyalu_tb.so"          # Linux
 [ -f "$LIB" ] || LIB="$CARGO_TARGET_DIR/$PROFDIR/libtinyalu_tb.dylib"  # macOS
-cp "$LIB" "$BUILD/tinyalu_tb.vpi"
-
-# timescale.v first: it sets 1ns/1ns for everything after it.
-iverilog -g2012 -o "$BUILD/tinyalu_rustdv.vvp" -s tinyalu hdl/timescale.v hdl/tinyalu.sv
-
 export RUSTDV_RANDOM_SEED="${RUSTDV_RANDOM_SEED:-1}"
 export RUSTDV_RESULTS_XML="${RUSTDV_RESULTS_XML:-$BUILD/results.xml}"
 
-vvp -M "$BUILD" -m tinyalu_tb "$BUILD/tinyalu_rustdv.vvp"
+case "$SIM" in
+  icarus)
+    cp "$LIB" "$BUILD/tinyalu_tb.vpi"
+    # timescale.v first: it sets 1ns/1ns for everything after it.
+    iverilog -g2012 -o "$BUILD/tinyalu_rustdv.vvp" -s tinyalu hdl/timescale.v hdl/tinyalu.sv
+    vvp -M "$BUILD" -m tinyalu_tb "$BUILD/tinyalu_rustdv.vvp"
+    ;;
+  verilator)
+    if [ "${RUSTDV_VERILATOR_MODE:-fast}" = debug ]; then
+      export RUSTDV_VERILATOR_CONTROL_FILE="${RUSTDV_VERILATOR_CONTROL_FILE:-$REPO_ROOT/sim/verilator-debug.vlt}"
+    fi
+    "$REPO_ROOT/sim/run_verilator.sh" "$LIB" tinyalu "$BUILD/verilator" \
+      "$REPO_ROOT/sim/hdl/timescale.v" "$REPO_ROOT/sim/hdl/tinyalu.sv"
+    ;;
+  *)
+    echo "unknown simulator: $SIM (use icarus|verilator)" >&2
+    exit 2
+    ;;
+esac

--- a/sim/run_smoke.sh
+++ b/sim/run_smoke.sh
@@ -4,9 +4,7 @@
 # Usage:  sim/run_smoke.sh [icarus|verilator|vcs|questa|xcelium]
 #         (or set SIM=...; the argument wins)
 #
-# Success criterion: prints "SMOKE: PASS" (Icarus & commercial sims run the
-# testbench; Verilator currently lints the DUT and prints "LINT: PASS" —
-# full Verilator simulation arrives with rustdv).
+# Success criterion: prints "SMOKE: PASS".
 set -euo pipefail
 cd "$(dirname "$0")"
 SIM="${1:-${SIM:-icarus}}"
@@ -38,8 +36,9 @@ case "$SIM" in
     # %Error-NEEDTIMINGOPT. Newer builds are lenient, which is exactly how this
     # reached CI green locally and red on Debian's 5.020 — the flag makes the
     # answer explicit on every version instead of version-dependent.
-    verilator --lint-only -sv --timing --top-module tinyalu "$HDL" -Mdir "$BUILD/obj_dir"
-    echo "LINT: PASS"
+    verilator --binary -sv --timing --top-module smoke_tb \
+      --Mdir "$BUILD/obj_dir" -o smoke "$TS" "$HDL" "$TB"
+    "$BUILD/obj_dir/smoke"
     ;;
   vcs)        # Synopsys — requires a license; untested in this repo's CI
     vcs -full64 -sverilog -o "$BUILD/simv" "$TS" "$HDL" "$TB"

--- a/sim/run_verilator.sh
+++ b/sim/run_verilator.sh
@@ -92,8 +92,17 @@ case "$MODE" in
         INPUTS+=("$CONTROL")
         FLAGS+=(--trace-fst)
         if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists liblz4; then
-            FLAGS+=(-CFLAGS "$(pkg-config --cflags liblz4)")
-            FLAGS+=(-LDFLAGS "$(pkg-config --libs liblz4)")
+            LZ4_CFLAGS="$(pkg-config --cflags liblz4)"
+            LZ4_LIBS="$(pkg-config --libs liblz4)"
+            # pkg-config omits system include directories on Linux, so
+            # --cflags may legitimately be empty. Passing `-CFLAGS ""` makes
+            # Verilator consume the following option incorrectly.
+            if [ -n "$LZ4_CFLAGS" ]; then
+                FLAGS+=(-CFLAGS "$LZ4_CFLAGS")
+            fi
+            if [ -n "$LZ4_LIBS" ]; then
+                FLAGS+=(-LDFLAGS "$LZ4_LIBS")
+            fi
         fi
         export RUSTDV_FST="${RUSTDV_FST:-$BUILD/${TOP}.fst}"
         ;;

--- a/sim/run_verilator.sh
+++ b/sim/run_verilator.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Build one rustdv VPI testbench against a Verilated DUT and run it.
+#
+# Usage: run_verilator.sh <vpi-library> <top-module> <build-dir> <hdl...>
+#
+# RUSTDV_VERILATOR_MODE:
+#   fast       top-level DUT ports only (default)
+#   debug      selected internals from RUSTDV_VERILATOR_CONTROL_FILE + FST
+#   framework  all signals visible; regression probes only
+set -euo pipefail
+
+if [ "$#" -lt 4 ]; then
+    echo "usage: $0 <vpi-library> <top-module> <build-dir> <hdl...>" >&2
+    exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$1"
+TOP="$2"
+BUILD="$3"
+shift 3
+HDL=("$@")
+MODE="${RUSTDV_VERILATOR_MODE:-fast}"
+THREADS="${RUSTDV_VERILATOR_THREADS:-1}"
+
+case "$THREADS" in
+    1|2|4) ;;
+    *) echo "rustdv: RUSTDV_VERILATOR_THREADS must be 1, 2, or 4" >&2; exit 2 ;;
+esac
+
+case "${RUSTDV_VERILATOR_OPT:-default}" in
+    default) OPT_FAST="-Os" ;;
+    o3) OPT_FAST="-O3" ;;
+    *) echo "rustdv: RUSTDV_VERILATOR_OPT must be default or o3" >&2; exit 2 ;;
+esac
+if [ "${RUSTDV_VERILATOR_NATIVE:-0}" = 1 ]; then
+    OPT_FAST="$OPT_FAST -march=native"
+fi
+
+if [[ ! "$TOP" =~ ^[A-Za-z_][A-Za-z0-9_\$]*$ ]]; then
+    echo "rustdv: unsupported Verilator top-module name: $TOP" >&2
+    exit 2
+fi
+
+if [ ! -f "$LIB" ]; then
+    echo "rustdv: VPI library not found: $LIB" >&2
+    exit 2
+fi
+
+version="$(verilator --version | awk '{print $2}')"
+if [[ ! "$version" =~ ^([0-9]+)\.([0-9]+) ]]; then
+    echo "rustdv: cannot parse Verilator version: $version" >&2
+    exit 2
+fi
+major=$((10#${BASH_REMATCH[1]}))
+minor=$((10#${BASH_REMATCH[2]}))
+if (( major < 5 || (major == 5 && minor < 50) )); then
+    echo "rustdv: Verilator >= 5.050 is required for runtime VPI loading (found $version)" >&2
+    exit 2
+fi
+
+mkdir -p "$BUILD"
+OBJ="$BUILD/obj_dir"
+EXE="$OBJ/rustdv_sim"
+LOG="$BUILD/verilator.log"
+
+FLAGS=(
+    --cc --exe
+    -sv --timing --vpi
+    --threads "$THREADS"
+    -CFLAGS "$OPT_FAST"
+    --prefix Vrustdv_dut
+    --top-module "$TOP"
+    --Mdir "$OBJ"
+    -o rustdv_sim
+)
+
+INPUTS=()
+case "$MODE" in
+    fast)
+        if [ -n "${RUSTDV_FST:-}" ]; then
+            echo "rustdv: FST tracing belongs to debug mode (set RUSTDV_VERILATOR_MODE=debug)" >&2
+            exit 2
+        fi
+        ;;
+    debug)
+        CONTROL="${RUSTDV_VERILATOR_CONTROL_FILE:-}"
+        if [ -z "$CONTROL" ] || [ ! -f "$CONTROL" ]; then
+            echo "rustdv: debug mode requires RUSTDV_VERILATOR_CONTROL_FILE=<file.vlt>" >&2
+            exit 2
+        fi
+        INPUTS+=("$CONTROL")
+        FLAGS+=(--trace-fst)
+        if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists liblz4; then
+            FLAGS+=(-CFLAGS "$(pkg-config --cflags liblz4)")
+            FLAGS+=(-LDFLAGS "$(pkg-config --libs liblz4)")
+        fi
+        export RUSTDV_FST="${RUSTDV_FST:-$BUILD/${TOP}.fst}"
+        ;;
+    framework)
+        FLAGS+=(--public-flat-rw)
+        ;;
+    *)
+        echo "rustdv: unknown RUSTDV_VERILATOR_MODE '$MODE' (use fast|debug|framework)" >&2
+        exit 2
+        ;;
+esac
+
+# C++ top-level ports are public by default, but Verilator's VPI namespace is
+# generated only for objects marked public_flat_rw.  Mark just the selected
+# DUT module's ports; this is deliberately narrower than --public-flat-rw.
+PORT_CONTROL="$BUILD/rustdv-top-ports.vlt"
+printf '%s\n' \
+    '`verilator_config' \
+    "public_flat_rw -module \"$TOP\" -port \"*\"" \
+    > "$PORT_CONTROL"
+if [ "${#INPUTS[@]}" -gt 0 ]; then
+    INPUTS=("$PORT_CONTROL" "${INPUTS[@]}")
+else
+    INPUTS=("$PORT_CONTROL")
+fi
+INPUTS+=("${HDL[@]}")
+verilator "${FLAGS[@]}" "${INPUTS[@]}" "$SCRIPT_DIR/verilator_main.cpp"
+make -C "$OBJ" -f Vrustdv_dut.mk -j "${RUSTDV_VERILATOR_JOBS:-1}" \
+    OPT_FAST="$OPT_FAST" OPT_GLOBAL="$OPT_FAST" OPT_SLOW="-O0"
+
+set +e
+"$EXE" "+verilator+vpi+$LIB" 2>&1 | tee "$LOG"
+sim_status=${PIPESTATUS[0]}
+set -e
+
+if [ "$sim_status" -ne 0 ]; then
+    echo "rustdv: Verilator host exited $sim_status" >&2
+    exit "$sim_status"
+fi
+if grep -q "REGRESSION: FAIL" "$LOG"; then
+    echo "rustdv: regression reported failure" >&2
+    exit 1
+fi
+if ! grep -q "REGRESSION: PASS" "$LOG"; then
+    echo "rustdv: simulator exited without a regression verdict" >&2
+    exit 1
+fi

--- a/sim/tb/smoke_tb.sv
+++ b/sim/tb/smoke_tb.sv
@@ -16,16 +16,15 @@ module smoke_tb;
    logic [2:0]  op;
    wire         done;
    wire [15:0]  result;
+   wire         clk;
 
    int          errors = 0;
 
-   tinyalu dut (.A, .B, .op, .reset_n, .start, .done, .result);
+   tinyalu dut (.A, .B, .op, .reset_n, .start, .clk, .done, .result);
 
    // The DUT supplies its own clock (D112), so this testbench watches it
    // rather than driving one. Nothing here may drive `clk`: two sources on
    // one signal is the bug this smoke test exists to rule out.
-   wire clk = dut.clk;
-
    // Hold start and operands until done asserts, then release.
    task do_op(input [7:0] a, input [7:0] b, input [2:0] o,
               input [15:0] expected);

--- a/sim/verilator-debug.vlt
+++ b/sim/verilator-debug.vlt
@@ -1,0 +1,8 @@
+`verilator_config
+
+// TinyALU DEBUG-mode instrumentation. Top-level ports, including clk, are
+// visible without directives; these are selected implementation signals.
+public_flat_rw -module "tinyalu" -var "result_aax"
+public_flat_rw -module "tinyalu" -var "result_mult"
+public_flat_rw -module "tinyalu" -var "start_single"
+public_flat_rw -module "tinyalu" -var "start_mult"

--- a/sim/verilator_main.cpp
+++ b/sim/verilator_main.cpp
@@ -1,0 +1,253 @@
+// Shared rustdv host for Verilated designs.
+//
+// Verilator's generated --main loop advances only while the RTL model has a
+// pending event.  A rustdv testbench can instead be waiting solely on a VPI
+// timer, so the generated loop may stop at time zero.  This host treats the
+// RTL and VPI queues as peers and implements the simulator phase ordering the
+// framework relies on.
+
+#include "Vrustdv_dut.h"
+#include "verilated.h"
+#include "verilated_vpi.h"
+
+#if VM_TRACE_FST
+#include "verilated_fst_c.h"
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <memory>
+
+// Statically linked VPI modules populate this array.  rustdv normally uses
+// Verilator 5.050's +verilator+vpi+<library> runtime loader, where it is null.
+extern "C" void (*vlog_startup_routines[])() VL_ATTR_WEAK;
+
+namespace {
+
+constexpr std::uint64_t kNoDeadline = std::numeric_limits<std::uint64_t>::max();
+constexpr unsigned kSettleLimit = 100000;
+
+struct SchedulerStats {
+    using Clock = std::chrono::steady_clock;
+
+    explicit SchedulerStats(double interval_seconds)
+        : enabled(interval_seconds > 0.0)
+        , interval(interval_seconds)
+        , started(Clock::now())
+        , last_report(started) {}
+
+    void note_outer_iteration(std::uint64_t sim_time) {
+        if (!enabled) return;
+        ++outer_iterations;
+        // Reading the host clock on every RTL/VPI deadline would distort the
+        // benchmark. Sampling once per 65,536 deadlines is frequent enough
+        // for progress while keeping the disabled path completely inert.
+        if ((outer_iterations & 0xffffU) != 0) return;
+        const auto now = Clock::now();
+        const double since_report = std::chrono::duration<double>(now - last_report).count();
+        if (since_report < interval) return;
+        const double wall = std::chrono::duration<double>(now - started).count();
+        std::fprintf(
+            stderr,
+            "RUSTDV_SCHEDULER_PROGRESS wall_s=%.3f sim_time=%llu deadlines=%llu "
+            "evals=%llu settle_extra=%llu timed=%llu value=%llu rw=%llu ro=%llu\n",
+            wall,
+            static_cast<unsigned long long>(sim_time),
+            static_cast<unsigned long long>(outer_iterations),
+            static_cast<unsigned long long>(eval_calls),
+            static_cast<unsigned long long>(settle_extra_iterations),
+            static_cast<unsigned long long>(timed_dispatches),
+            static_cast<unsigned long long>(value_dispatches),
+            static_cast<unsigned long long>(read_write_dispatches),
+            static_cast<unsigned long long>(read_only_dispatches));
+        last_report = now;
+    }
+
+    void report_final(std::uint64_t sim_time) const {
+        if (!enabled) return;
+        const double wall = std::chrono::duration<double>(Clock::now() - started).count();
+        std::fprintf(
+            stderr,
+            "RUSTDV_SCHEDULER_SUMMARY wall_s=%.3f sim_time=%llu deadlines=%llu "
+            "evals=%llu settle_extra=%llu timed=%llu value=%llu rw=%llu ro=%llu\n",
+            wall,
+            static_cast<unsigned long long>(sim_time),
+            static_cast<unsigned long long>(outer_iterations),
+            static_cast<unsigned long long>(eval_calls),
+            static_cast<unsigned long long>(settle_extra_iterations),
+            static_cast<unsigned long long>(timed_dispatches),
+            static_cast<unsigned long long>(value_dispatches),
+            static_cast<unsigned long long>(read_write_dispatches),
+            static_cast<unsigned long long>(read_only_dispatches));
+    }
+
+    bool enabled = false;
+    double interval = 0.0;
+    Clock::time_point started;
+    Clock::time_point last_report;
+    std::uint64_t outer_iterations = 0;
+    std::uint64_t eval_calls = 0;
+    std::uint64_t settle_extra_iterations = 0;
+    std::uint64_t timed_dispatches = 0;
+    std::uint64_t value_dispatches = 0;
+    std::uint64_t read_write_dispatches = 0;
+    std::uint64_t read_only_dispatches = 0;
+};
+
+double progress_interval_seconds() {
+    const char* value = std::getenv("RUSTDV_VERILATOR_PROGRESS_SECONDS");
+    if (!value || !*value) return 0.0;
+    char* end = nullptr;
+    const double parsed = std::strtod(value, &end);
+    if (!end || *end || parsed <= 0.0) {
+        std::fprintf(
+            stderr,
+            "rustdv: RUSTDV_VERILATOR_PROGRESS_SECONDS must be positive, got %s\n",
+            value);
+        return -1.0;
+    }
+    return parsed;
+}
+
+std::uint32_t runtime_threads() {
+    const char* value = std::getenv("RUSTDV_VERILATOR_THREADS");
+    if (!value || !*value) return 1;
+    char* end = nullptr;
+    const unsigned long parsed = std::strtoul(value, &end, 10);
+    if (!end || *end || parsed == 0 || parsed > 4) {
+        std::fprintf(stderr, "rustdv: invalid RUSTDV_VERILATOR_THREADS=%s\n", value);
+        return 0;
+    }
+    return static_cast<std::uint32_t>(parsed);
+}
+
+bool settle(Vrustdv_dut& dut, SchedulerStats* stats) {
+    for (unsigned iteration = 0; iteration < kSettleLimit; ++iteration) {
+        // Apply any inertially delayed VPI writes before evaluating the RTL.
+        // Clear the dirty flag because this eval consumes all writes made so
+        // far; writes made by callbacks below set it again.
+        VerilatedVpi::doInertialPuts();
+        VerilatedVpi::clearEvalNeeded();
+        dut.eval();
+        if (stats) {
+            ++stats->eval_calls;
+            if (iteration != 0) ++stats->settle_extra_iterations;
+        }
+
+        // RTL changes wake edge/value awaiters. AtEnd callbacks precede the
+        // ReadWrite and ReadOnly regions in Verilator's generated host; either
+        // callback class may queue writes, so ReadOnly is not legal until this
+        // reaches a fixed point.
+        VerilatedVpi::callValueCbs();
+        VerilatedVpi::callCbs(cbAtEndOfSimTime);
+        VerilatedVpi::callCbs(cbReadWriteSynch);
+        if (stats) {
+            ++stats->value_dispatches;
+            ++stats->read_write_dispatches;
+        }
+
+        if (!VerilatedVpi::evalNeeded()
+            && !VerilatedVpi::hasCbs(cbReadWriteSynch)) {
+            VerilatedVpi::callCbs(cbReadOnlySynch);
+            if (stats) ++stats->read_only_dispatches;
+            return true;
+        }
+    }
+
+    std::fprintf(stderr,
+                 "rustdv: Verilator scheduler did not settle after %u iterations at time %llu\n",
+                 kSettleLimit,
+                 static_cast<unsigned long long>(Verilated::time()));
+    return false;
+}
+
+}  // namespace
+
+int main(int argc, char** argv, char**) {
+    Verilated::debug(0);
+    const std::unique_ptr<VerilatedContext> contextp{new VerilatedContext};
+    const std::uint32_t threads = runtime_threads();
+    const double progress_interval = progress_interval_seconds();
+    if (threads == 0 || progress_interval < 0.0) return 2;
+    SchedulerStats stats(progress_interval);
+    SchedulerStats* const statsp = stats.enabled ? &stats : nullptr;
+    contextp->threads(threads);
+    contextp->commandArgs(argc, argv);
+
+    const std::unique_ptr<Vrustdv_dut> dutp{new Vrustdv_dut{contextp.get(), ""}};
+
+#if VM_TRACE_FST
+    std::unique_ptr<VerilatedFstC> tracep;
+    if (const char* const path = std::getenv("RUSTDV_FST")) {
+        contextp->traceEverOn(true);
+        tracep = std::make_unique<VerilatedFstC>();
+        dutp->trace(tracep.get(), 99);
+        tracep->open(path);
+    }
+#else
+    if (std::getenv("RUSTDV_FST")) {
+        std::fprintf(stderr,
+                     "rustdv: RUSTDV_FST was set, but this model was not built with --trace-fst\n");
+        return 2;
+    }
+#endif
+
+    if (vlog_startup_routines) {
+        for (auto routinep = &vlog_startup_routines[0]; *routinep; ++routinep) {
+            (*routinep)();
+        }
+    }
+    VerilatedVpi::callCbs(cbStartOfSimulation);
+
+    bool scheduler_ok = true;
+    while (!contextp->gotFinish()) {
+        if (statsp) stats.note_outer_iteration(contextp->time());
+        // Timed callbacks run before model evaluation at their deadline.
+        VerilatedVpi::callTimedCbs();
+        VerilatedVpi::callCbs(cbNextSimTime);
+        VerilatedVpi::callCbs(cbAtStartOfSimTime);
+        if (statsp) ++stats.timed_dispatches;
+
+        if (!settle(*dutp, statsp)) {
+            scheduler_ok = false;
+            break;
+        }
+
+#if VM_TRACE_FST
+        if (tracep) tracep->dump(contextp->time());
+#endif
+
+        if (contextp->gotFinish()) break;
+
+        const std::uint64_t rtl_deadline
+            = dutp->eventsPending() ? dutp->nextTimeSlot() : kNoDeadline;
+        const std::uint64_t vpi_deadline = VerilatedVpi::cbNextDeadline();
+        const std::uint64_t deadline = std::min(rtl_deadline, vpi_deadline);
+
+        if (deadline == kNoDeadline) break;
+        if (deadline < contextp->time()) {
+            std::fprintf(stderr,
+                         "rustdv: Verilator scheduler deadline moved backwards (%llu < %llu)\n",
+                         static_cast<unsigned long long>(deadline),
+                         static_cast<unsigned long long>(contextp->time()));
+            scheduler_ok = false;
+            break;
+        }
+        contextp->time(deadline);
+    }
+
+    dutp->final();
+    VerilatedVpi::callCbs(cbEndOfSimulation);
+    stats.report_final(contextp->time());
+
+#if VM_TRACE_FST
+    if (tracep) tracep->close();
+#endif
+
+    contextp->statsPrintSummary();
+    return scheduler_ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

This adds a full Verilator VPI simulation backend to RustDV. It runs the real Rust testbench rather than using Verilator only as a lint target.

- Add a shared Verilator host that advances to the earliest RTL event or VPI deadline, dispatches timed/value/phase callbacks, re-evaluates after VPI writes, settles to a fixed point, and handles startup, shutdown, `$finish`, `final()`, and tracing.
- Add a simulator runner with a fixed generated-model prefix and FAST, DEBUG, and framework visibility modes.
- Add optional FST tracing, `-O3`, native-code, model-thread, and scheduler-progress controls.
- Speed up common VPI operations with `vpiVectorVal`, cached immutable signal widths, and numeric scalar edge checks.
- Correctly release fired one-shot callback handles so long simulations reach an RSS plateau.
- Add Linux/macOS CI coverage with pinned Verilator 5.050 and targeted scheduler, lifecycle, mutation, debug, and TinyALU regressions.

## Why

Verilator's generated event loop considers delayed RTL events, but a RustDV testbench may be waiting only on a pending VPI timer. The shared host treats both queues as peers and supplies the callback-region and fixed-point scheduling that RustDV requires.

FAST mode exposes only top-level DUT ports. DEBUG mode exposes deliberately selected internals through a Verilator control file and enables FST. Full `--public-flat-rw` visibility is limited to the small framework regression.

Verilator remains a two-state functional simulator; Icarus remains the four-state framework reference.

## Performance evidence

The portable VPI path was also exercised outside this repository on a substantial 4K video-codec testbench with a 128-bit AXI-4 interface: 18,811,285 processing cycles, 4,320 completed slices, and almost six million AXI read beats. It completed in 102.93 seconds versus a recorded 769.72-second cocotb FAST run, a 7.48x simulator-time improvement, while matching the expected completion cycle, slice count, error status, and AXI transaction counts.

That codec is not included here, and this is not intended as a universal Rust-versus-Python claim. Background and methodology are in [Discussion #4](https://github.com/rustdv/rustdv/discussions/4).

## Validation

- `cargo test --workspace --offline` — passed (117 workspace tests, including 9 `rustdv-gpi` tests)
- `python3 output/regression/regress.py --suite custom --filter verilator` — 6 passed, 0 failed
- Scheduler regression — 37 selected framework tests, including earliest RTL/VPI deadline selection, AtEnd -> ReadWrite -> ReadOnly ordering, RTL settling after VPI writes, `final()`, and end-of-simulation delivery
- Callback lifecycle regression — one million callback iterations with bounded RSS growth
- `git diff --check upstream/master` — passed

Icarus was not installed on the development machine, so the local four-state simulator suite was not rerun. The added Linux CI job installs Icarus and runs the complete simulator regression.
