### PR TITLE
Fix Verilator FST link failure on Apple Silicon

### DIFF
--- a/TOUR.md
+++ b/TOUR.md
@@ -26,10 +26,11 @@ pyuvm story retold with a compiler: a simulator-driven async executor,
 triggers, a UVM-style component methodology (ownership tree, typed
 configs, maker-closure factories, channels/analysis ports, the full
 sequencer handshake), running testbenches as native shared libraries
-loaded by Icarus Verilog over VPI. Zero external dependencies. **v0.1 is
+loaded over VPI by Icarus Verilog — the four-state reference — or by Verilator
+as the fast two-state backend. Zero external dependencies. **v0.1 is
 publicly live** (2026-08-06/07): `rustdv` 0.1.1 is published on crates.io,
-the `rustdv/rustdv` GitHub repo is public with Discussions on and
-Issues/PRs off, and the companion site is up at rustdv.org.
+the `rustdv/rustdv` GitHub repo is public with Discussions, Issues and pull
+requests all open, and the companion site is up at rustdv.org.
 
 **"Rust for RTL Verification"** is its book — the third in Ray Salemi's
 series after [*The UVM Primer*](https://www.uvmprimer.com) (SystemVerilog)
@@ -147,6 +148,16 @@ or similar) and to nobody else:
   script writes its `.vpi`/`.vvp` before running it. Source and documents into
   the repo, yes; `.vpi`, `.vvp`, `.so`, `.dylib`, object files and simulator
   output directories, no.
+- **`custom/sim-debug-verilator` cannot pass in the Cowork VM — this is not a
+  regression.** Verilator's FST writer compiles `verilated_fst_c.cpp`, which
+  includes `<lz4.h>`; the `oss-cad-suite` bundle in `toolchain-drop/` does not
+  ship the lz4 development header, the VM has no network, and `apt-get` has no
+  root. The failure is `fatal error: lz4.h: No such file or directory` at exit
+  2. Every other Verilator entry — `sim-tinyalu-tb-verilator`,
+  `sim-mutation-verilator`, `sim-scheduler-verilator`,
+  `sim-callback-lifecycle-verilator`, `sim-lint-verilator` — passes here, so a
+  single `sim-debug-verilator` failure alongside those means the header, not the
+  code. Confirm FST tracing on the Mac.
 - **A green sandbox run is evidence about the sandbox.** macOS/arm64 is a
   shipping platform for this project. Say "verified on Linux" when that is what
   happened, and ask Ray to confirm on the Mac before calling anything done. The

--- a/output/regression/TESTING.md
+++ b/output/regression/TESTING.md
@@ -95,6 +95,19 @@ repeats the Verilator runtime, scheduler, DEBUG/FST, and mutation entries.
 Commercial simulators cannot run in public CI; license-holders run
 `sim/run_smoke.sh <sim>` locally.
 
+**`sim-debug-verilator` needs lz4 installed** — `liblz4-dev` on Debian/Ubuntu,
+`brew install lz4` on macOS. Verilator's FST writer links `liblz4`, and without
+it the DEBUG build stops at `fatal error: lz4.h: No such file or directory`.
+CI installs it on both platforms; a fresh developer machine may not have it.
+
+On macOS `sim/run_verilator.sh` takes the lz4 paths from `brew --prefix lz4`
+rather than `pkg-config`, because a Mac that once ran Intel Homebrew keeps an
+x86_64 `liblz4.pc` under `/usr/local` and pkg-config will hand Verilator that
+prefix — the compile succeeds, then the arm64 link fails on undefined
+`_LZ4_compressBound`. **No check covers this.** GitHub's macOS runners are
+arm64 with only arm64 Homebrew, so CI cannot reproduce a stale Intel prefix;
+this one is a comment in the script, not a test.
+
 The rule of thumb: **every new piece of functionality lands together with the
 test that would catch its removal.** The pre-push hook then makes it
 structurally hard to break something silently.

--- a/rustdv/getting-started-with-rustdv.md
+++ b/rustdv/getting-started-with-rustdv.md
@@ -26,7 +26,7 @@ well.
    ```
    The repository pins its compiler in `rust-toolchain.toml`, so inside a
    clone `rustup` fetches the right one on its own.
-2. **Icarus Verilog** — the simulator rustdv currently supports:
+2. **Icarus Verilog** — the four-state reference simulator:
    ```sh
    sudo apt install iverilog     # Debian/Ubuntu
    brew install icarus-verilog   # macOS
@@ -36,14 +36,22 @@ well.
    The run scripts compile with `-g2012`, so you need a build with
    SystemVerilog-2012 support. Any current Icarus has it; the oss-cad-suite
    build is the one this project is tested against.
-3. Optional but recommended: **VS Code + rust-analyzer** (use model 1) or
+3. **Verilator** — optional, and the fast two-state backend:
+   ```sh
+   sudo apt install verilator zlib1g-dev liblz4-dev   # Debian/Ubuntu
+   brew install verilator lz4                          # macOS
+   verilator --version
+   ```
+   **lz4 is not optional if you want waveforms.** Verilator's FST writer links
+   `liblz4`, so `RUSTDV_VERILATOR_MODE=debug` fails to build without it. Every
+   other Verilator mode runs fine.
+4. Optional but recommended: **VS Code + rust-analyzer** (use model 1) or
    **Claude Code / Cowork** (use model 2), and **GTKWave** for waveforms.
 
-> Platform note: rustdv's simulator backend is VPI-based and is developed
-> and tested on Linux with Icarus. macOS generally works; Windows users
-> should work inside WSL. Verilator is linted against but not yet run as a
-> simulator, and commercial simulators are not supported today. `STATUS.md`
-> in the repository records what has actually been run, and where.
+> Platform note: rustdv's simulator backend is VPI-based and is developed and
+> tested on Linux and macOS with Icarus and Verilator. Windows users should
+> work inside WSL, and commercial simulators are not supported today.
+> `STATUS.md` in the repository records what has actually been run, and where.
 
 ## Step 1: Clone rustdv and prove your setup works
 

--- a/sim/run_verilator.sh
+++ b/sim/run_verilator.sh
@@ -91,18 +91,31 @@ case "$MODE" in
         fi
         INPUTS+=("$CONTROL")
         FLAGS+=(--trace-fst)
-        if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists liblz4; then
+        # Verilator's FST writer links liblz4. Ask Homebrew before pkg-config on
+        # macOS: a Mac that once ran Intel Homebrew keeps an x86_64 lz4 and its
+        # .pc file under /usr/local, pkg-config answers with that prefix, and the
+        # arm64 link fails on undefined _LZ4_compressBound after the linker
+        # reports "ignoring file ... found architecture 'x86_64'". `brew --prefix`
+        # is arch-correct by construction; pkg-config is not.
+        LZ4_CFLAGS=""
+        LZ4_LIBS=""
+        if [ "$(uname -s)" = "Darwin" ] && command -v brew >/dev/null 2>&1 \
+           && LZ4_PREFIX="$(brew --prefix lz4 2>/dev/null)" \
+           && [ -d "$LZ4_PREFIX/lib" ]; then
+            LZ4_CFLAGS="-I$LZ4_PREFIX/include"
+            LZ4_LIBS="-L$LZ4_PREFIX/lib -llz4"
+        elif command -v pkg-config >/dev/null 2>&1 && pkg-config --exists liblz4; then
             LZ4_CFLAGS="$(pkg-config --cflags liblz4)"
             LZ4_LIBS="$(pkg-config --libs liblz4)"
-            # pkg-config omits system include directories on Linux, so
-            # --cflags may legitimately be empty. Passing `-CFLAGS ""` makes
-            # Verilator consume the following option incorrectly.
-            if [ -n "$LZ4_CFLAGS" ]; then
-                FLAGS+=(-CFLAGS "$LZ4_CFLAGS")
-            fi
-            if [ -n "$LZ4_LIBS" ]; then
-                FLAGS+=(-LDFLAGS "$LZ4_LIBS")
-            fi
+        fi
+        # pkg-config omits system include directories on Linux, so --cflags may
+        # legitimately be empty. Passing `-CFLAGS ""` makes Verilator consume the
+        # following option incorrectly.
+        if [ -n "$LZ4_CFLAGS" ]; then
+            FLAGS+=(-CFLAGS "$LZ4_CFLAGS")
+        fi
+        if [ -n "$LZ4_LIBS" ]; then
+            FLAGS+=(-LDFLAGS "$LZ4_LIBS")
         fi
         export RUSTDV_FST="${RUSTDV_FST:-$BUILD/${TOP}.fst}"
         ;;


### PR DESCRIPTION
`sim-debug-verilator` failed on macOS with an undefined `_LZ4_compressBound` at link time.

`sim/run_verilator.sh` took its lz4 flags from `pkg-config`. On a Mac that once ran Intel Homebrew, a stale x86_64 `liblz4.pc` remains under `/usr/local`, so Verilator was handed `-L/usr/local/opt/lz4/lib`; the compile succeeded, the linker reported `ignoring file ... found architecture 'x86_64'`, and the arm64 link failed.

macOS now takes the lz4 paths from `brew --prefix lz4`, which is arch-correct by construction. Linux keeps the pkg-config path unchanged.

Also documents lz4 as a local prerequisite — CI installs `liblz4-dev`/`lz4` on both platforms but the setup docs never said so — and updates the Verilator status in `getting-started-with-rustdv.md`, which still read "linted against but not yet run as a simulator."

No check covers the stale-prefix case: GitHub's macOS runners are arm64 with only arm64 Homebrew, so CI cannot reproduce it. Noted in TESTING.md.

Verified: full regression green on macOS/arm64.