### PR TITLE
Add settled Verilator debug service points

### DIFF
--- a/output/regression/tests/sim-inspect-verilator/run.sh
+++ b/output/regression/tests/sim-inspect-verilator/run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Prove INSPECT mode exposes selected VPI state without building or emitting a waveform.
+set -euo pipefail
+cd "$(dirname "$0")/../../../.."
+
+BUILD="$(mktemp -d /tmp/rustdv-inspect-regression.XXXXXX)"
+SIM_BUILD_DIR="$BUILD" RUSTDV_VERILATOR_MODE=inspect \
+    bash sim/run_rustdv.sh release verilator
+
+FST="$(find "$BUILD" -type f -name '*.fst' -print -quit)"
+if [ -n "$FST" ]; then
+    echo "INSPECT NO FST: FAIL — emitted $FST" >&2
+    exit 1
+fi
+echo "INSPECT NO FST: PASS"
+
+# The mode is deliberately no-waveform: reject an FST request before doing a
+# second Verilator build. The successful run above has already built the VPI
+# library in the shared cargo target directory.
+TARGET_ROOT="${CARGO_TARGET_DIR:-/tmp/rustdv-$(id -u)/target}"
+LIB="$TARGET_ROOT/release/libtinyalu_tb.so"
+[ -f "$LIB" ] || LIB="$TARGET_ROOT/release/libtinyalu_tb.dylib"
+set +e
+REJECT_OUTPUT="$({
+    RUSTDV_VERILATOR_MODE=inspect \
+    RUSTDV_VERILATOR_CONTROL_FILE="$PWD/sim/verilator-debug.vlt" \
+    RUSTDV_FST="$BUILD/unwanted.fst" \
+        bash sim/run_verilator.sh "$LIB" tinyalu "$BUILD/reject-fst" \
+        sim/hdl/timescale.v sim/hdl/tinyalu.sv
+} 2>&1)"
+REJECT_STATUS=$?
+set -e
+if [ "$REJECT_STATUS" -ne 2 ] || [[ "$REJECT_OUTPUT" != *"FST tracing belongs to debug mode"* ]]; then
+    echo "INSPECT FST REJECTION: FAIL — status=$REJECT_STATUS" >&2
+    echo "$REJECT_OUTPUT" >&2
+    exit 1
+fi
+echo "INSPECT FST REJECTION: PASS"

--- a/output/regression/tests/sim-inspect-verilator/test.json
+++ b/output/regression/tests/sim-inspect-verilator/test.json
@@ -1,0 +1,15 @@
+{
+  "comment": "Verilator INSPECT policy: TinyALU runs with selected control-file visibility, emits no FST, and rejects an explicit waveform request.",
+  "cmd": ["bash", "output/regression/tests/sim-inspect-verilator/run.sh"],
+  "cwd": ".",
+  "skip_if_missing": "verilator",
+  "expect_exit": 0,
+  "timeout": 600,
+  "expect_in_output": [
+    "REGRESSION: PASS",
+    "scoreboard: 20 compared, 0 mismatches",
+    "coverage: Add=5 And=5 Mul=5 Xor=5",
+    "INSPECT NO FST: PASS",
+    "INSPECT FST REJECTION: PASS"
+  ]
+}

--- a/output/regression/tests/sim-stable-point-verilator/test.json
+++ b/output/regression/tests/sim-stable-point-verilator/test.json
@@ -1,0 +1,20 @@
+{
+  "comment": "Opt-in stable-point service runs on the Verilator simulator thread after fixed-point ReadOnly settle, can wait for a worker release with simulation time frozen, then releases normal simulation progress.",
+  "cmd": ["bash", "rustdv/framework-tests/run.sh"],
+  "cwd": ".",
+  "skip_if_missing": "verilator",
+  "env": {
+    "SIM": "verilator",
+    "RUSTDV_TESTCASE": "stable_point_"
+  },
+  "expect_exit": 0,
+  "timeout": 600,
+  "expect_in_output": [
+    "rustdv: found 3 test(s)",
+    "stable_point_service_holds_settled_read_only PASSED",
+    "stable_point_service_panic_is_contained PASSED",
+    "stable_point_service_is_available_after_prior_panic PASSED",
+    "REGRESSION: PASS",
+    "RTL FINAL: PASS"
+  ]
+}

--- a/rustdv/framework-tests/src/framework_tests.rs
+++ b/rustdv/framework-tests/src/framework_tests.rs
@@ -35,6 +35,7 @@
 //! | `conc_` | [`concurrency`] | the D82 family, against real time |
 //! | `elab_` | [`elaboration`] | unconnected ports fail before the run phase |
 //! | `runner_` | [`runner`] | timeouts, `expect_error`, per-test freshness |
+//! | `stable_point_` | [`triggers`] | synchronous service at settled ReadOnly |
 //! | `callback_stress_` | [`callback_lifecycle`] | fired one-shot handles reach an RSS plateau |
 //!
 //! The DUT is `hdl/probe.sv`: a clock, signals of known widths that nothing

--- a/rustdv/framework-tests/src/triggers.rs
+++ b/rustdv/framework-tests/src/triggers.rs
@@ -6,6 +6,8 @@
 
 use std::cell::Cell;
 use std::rc::Rc;
+use std::sync::mpsc;
+use std::time::Duration;
 
 use rustdv::prelude::*;
 
@@ -297,6 +299,114 @@ async fn trig_read_only_sees_settled_rtl(ctx: RustdvCtx) -> Result<(), TestError
 
     let got = output.get_u64().unwrap_or(0);
     check!(got == (0x3C ^ 0xA5), "ReadOnly saw comb_out={got:#x} before RTL settled");
+    Ok(())
+}
+
+// An opted-in service runs only after the design has fixed-point settled at
+// ReadOnly. It may synchronously wait for an ordinary OS worker while the
+// simulator thread — and therefore simulation time — remains held.
+#[rustdv::test]
+async fn stable_point_service_holds_settled_read_only(
+    ctx: RustdvCtx,
+) -> Result<(), TestError> {
+    let input = ctx.dut().signal("comb_in")?;
+    let output = ctx.dut().signal("comb_out")?;
+    let clk = ctx.dut().signal("clk")?;
+    Clock::new(&clk, SimDuration::ns(2)).start();
+
+    input.set_u64(0x6C);
+
+    let (entered_tx, entered_rx) = mpsc::channel();
+    let (release_tx, release_rx) = mpsc::channel();
+    let worker = std::thread::spawn(move || -> Result<(), String> {
+        let held_time = entered_rx
+            .recv_timeout(Duration::from_secs(5))
+            .map_err(|e| format!("worker did not observe the held stable point: {e}"))?;
+        std::thread::sleep(Duration::from_millis(50));
+        release_tx
+            .send(held_time)
+            .map_err(|e| format!("worker could not release the stable point: {e}"))
+    });
+
+    let held = service_read_only(move || -> Result<_, String> {
+        let before = rustdv::sim_time_steps();
+        let settled = output
+            .get_u64()
+            .map_err(|e| format!("could not read settled combinational output: {e}"))?;
+        entered_tx
+            .send(before)
+            .map_err(|e| format!("could not notify worker of stable point: {e}"))?;
+        let worker_time = release_rx
+            .recv_timeout(Duration::from_secs(5))
+            .map_err(|e| format!("worker did not release the stable point: {e}"))?;
+        let after = rustdv::sim_time_steps();
+        Ok((settled, before, after, worker_time))
+    })
+    .await
+    .map_err(TestError::new)?;
+
+    worker
+        .join()
+        .map_err(|_| TestError::new("stable-point worker panicked"))?
+        .map_err(TestError::new)?;
+
+    check!(
+        held.0 == (0x6C ^ 0xA5),
+        "stable-point service saw comb_out={:#x} before RTL settled",
+        held.0
+    );
+    check!(
+        held.1 == held.2 && held.1 == held.3,
+        "simulation time changed while held: entered={}, released={}, worker={}",
+        held.1,
+        held.2,
+        held.3
+    );
+
+    let released_at = rustdv::sim_time_steps();
+    Timer::ns(2).await;
+    check!(
+        rustdv::sim_time_steps() > released_at,
+        "simulation did not advance after the worker released the stable point"
+    );
+    Ok(())
+}
+
+// A service panic unwinds to RustDV's task boundary. The runner contains it
+// as this test's expected failure instead of losing the simulator callback or
+// aborting the process. The following test proves a later test can service the
+// simulator normally after the runner has left the prior ReadOnly phase.
+#[rustdv::test(expect_fail)]
+async fn stable_point_service_panic_is_contained(_ctx: RustdvCtx) -> Result<(), TestError> {
+    service_read_only(|| {
+        panic!("deliberate stable-point service panic");
+    })
+    .await;
+    Ok(())
+}
+
+#[rustdv::test]
+async fn stable_point_service_is_available_after_prior_panic(
+    ctx: RustdvCtx,
+) -> Result<(), TestError> {
+    let input = ctx.dut().signal("comb_in")?;
+    let output = ctx.dut().signal("comb_out")?;
+    input.set_u64(0x93);
+
+    let (settled, held_at) = service_read_only(move || {
+        (output.get_u64().unwrap_or(0), rustdv::sim_time_steps())
+    })
+    .await;
+    check!(
+        settled == (0x93 ^ 0xA5),
+        "later stable-point service saw comb_out={settled:#x} before RTL settled"
+    );
+
+    Timer::ns(1).await;
+    check!(
+        rustdv::sim_time_steps() > held_at,
+        "simulation did not advance after the recovered stable-point service"
+    );
     Ok(())
 }
 

--- a/rustdv/rustdv-sim/src/phase.rs
+++ b/rustdv/rustdv-sim/src/phase.rs
@@ -264,6 +264,34 @@ pub fn read_only() -> PhaseFut {
     PhaseFut { kind: PhaseKind::ReadOnly, registered: false }
 }
 
+/// Run one synchronous service operation at a settled ReadOnly point.
+///
+/// The closure runs on the simulator thread from inside the simulator's
+/// ReadOnly callback, after pending writes and combinational logic have
+/// reached a fixed point. It may communicate with other OS threads through
+/// ordinary synchronization primitives. While it is waiting, the simulator
+/// callback cannot return, so simulation time remains frozen. Returning the
+/// closure's value releases the simulator to advance normally.
+///
+/// # Blocking and cancellation
+///
+/// Any wait in `service` must be bounded by wall-clock time or use a
+/// cooperative cancellation signal. A simulation-time timeout cannot fire
+/// while this function holds ReadOnly, and RustDV cannot forcibly recover an
+/// arbitrary blocking closure. An unbounded wait will therefore wedge the
+/// simulation.
+///
+/// This is opt-in and transport-neutral: RustDV does not create a worker,
+/// scheduler, or server. A testbench supplies both the service closure and any
+/// channels or synchronization it needs.
+pub async fn service_read_only<F, R>(service: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    read_only().await;
+    service()
+}
+
 /// Await the next simulator time step (port of `NextTimeStep()`).
 pub fn next_time_step() -> PhaseFut {
     PhaseFut { kind: PhaseKind::NextTimeStep, registered: false }

--- a/rustdv/rustdv-sim/src/rustdv_sim.rs
+++ b/rustdv/rustdv-sim/src/rustdv_sim.rs
@@ -33,7 +33,7 @@ pub use combinators::{first2, join2, join_all, with_timeout, Either, TimeoutErro
 pub use executor::{spawn, spawn_named, Executor, TaskError, TaskHandle, TaskId, TaskState};
 pub use path::RustdvPath;
 pub use handle::{AnyHandle, HierarchyHandle, LogicHandle};
-pub use phase::{read_only, read_write, next_time_step};
+pub use phase::{next_time_step, read_only, read_write, service_read_only};
 pub use queue::Queue;
 pub use rng::Rng;
 pub use sync::{Event, Lock, LockGuard};

--- a/rustdv/src/rustdv.rs
+++ b/rustdv/src/rustdv.rs
@@ -42,10 +42,11 @@ pub use rustdv_sim::{first, join};
 pub use rustdv_runner::TestRegistration;
 
 pub use rustdv_sim::{
-    first2, join2, next_time_step, read_only, read_write, sim_time_ns, sim_time_steps, spawn,
-    spawn_named, with_timeout, AnyHandle, Clock, Either, Event, Executor, HandleError, RustdvPath,
-    HierarchyHandle, Lock, LockGuard, Logic, LogicArray, LogicHandle, NullTrigger, Queue, Rng,
-    SimDuration, TaskError, TaskHandle, TaskState, TimeoutError, Timer, ValueError,
+    first2, join2, next_time_step, read_only, read_write, service_read_only, sim_time_ns,
+    sim_time_steps, spawn, spawn_named, with_timeout, AnyHandle, Clock, Either, Event, Executor,
+    HandleError, RustdvPath, HierarchyHandle, Lock, LockGuard, Logic, LogicArray, LogicHandle,
+    NullTrigger, Queue, Rng, SimDuration, TaskError, TaskHandle, TaskState, TimeoutError, Timer,
+    ValueError,
 };
 pub use rustdv_sim::handle::top_module;
 pub use rustdv_sim::log;
@@ -76,8 +77,9 @@ pub mod prelude {
     pub use crate::{
         build_all, channel, check_all, connect_all, end_of_elaboration_all, extract_all, final_all,
         first2, join2, next_time_step, print_hierarchy, read_only, read_write, report_all,
-        run_component_test, run_extract_check_report, sim_time_ns, spawn, spawn_named, start_all,
-        start_of_simulation_all, with_timeout, Active, AnalysisBus, CheckSink, Clock,
+        run_component_test, run_extract_check_report, service_read_only, sim_time_ns, spawn,
+        spawn_named, start_all, start_of_simulation_all, with_timeout, Active, AnalysisBus,
+        CheckSink, Clock,
         RustdvComp, Component, ComponentNode, Either, Event, Factory, HandleError, HierarchyHandle,
         Lock, Logic, LogicArray, LogicHandle, NullTrigger, ObjectionGuard, Queue, Receiver, Rng,
         create_seq, set_seq_override,

--- a/sim/README.md
+++ b/sim/README.md
@@ -38,19 +38,22 @@ Run the Rust testbench with either backend:
 sim/run_rustdv.sh release icarus
 sim/run_rustdv.sh release verilator
 RUSTDV_VERILATOR_MODE=debug sim/run_rustdv.sh release verilator
+RUSTDV_VERILATOR_MODE=inspect sim/run_rustdv.sh release verilator
 ```
 
-The last command writes an FST under `/tmp/rustdv-$(id -u)/`. FAST exposes
-only top-level ports; DEBUG adds the signals in a Verilator control file; the
-small framework probe alone uses full visibility. Verilator 5.050 or newer is
-required for runtime VPI library loading.
+DEBUG writes an FST under `/tmp/rustdv-$(id -u)/`. FAST exposes only top-level
+ports; DEBUG adds the signals in a Verilator control file and an FST; INSPECT
+adds the same selected VPI visibility without building or emitting a waveform.
+The small framework probe alone uses full visibility. Verilator 5.050 or newer
+is required for runtime VPI library loading. The TinyALU entry point defaults
+the DEBUG and INSPECT control file to `sim/verilator-debug.vlt`.
 
 Useful Verilator controls are:
 
 | Variable | Values | Purpose |
 |---|---|---|
-| `RUSTDV_VERILATOR_MODE` | `fast`, `debug`, `framework` | visibility and tracing policy |
-| `RUSTDV_VERILATOR_CONTROL_FILE` | path to `.vlt` | selected DEBUG internals |
+| `RUSTDV_VERILATOR_MODE` | `fast`, `debug`, `inspect`, `framework` | visibility and tracing policy |
+| `RUSTDV_VERILATOR_CONTROL_FILE` | path to `.vlt` | selected DEBUG/INSPECT internals |
 | `RUSTDV_FST` | output path | DEBUG waveform location |
 | `RUSTDV_VERILATOR_OPT` | `default`, `o3` | generated-model optimization |
 | `RUSTDV_VERILATOR_THREADS` | `1`, `2`, `4` | Verilated model threads |

--- a/sim/run_rustdv.sh
+++ b/sim/run_rustdv.sh
@@ -53,9 +53,11 @@ case "$SIM" in
     vvp -M "$BUILD" -m tinyalu_tb "$BUILD/tinyalu_rustdv.vvp"
     ;;
   verilator)
-    if [ "${RUSTDV_VERILATOR_MODE:-fast}" = debug ]; then
-      export RUSTDV_VERILATOR_CONTROL_FILE="${RUSTDV_VERILATOR_CONTROL_FILE:-$REPO_ROOT/sim/verilator-debug.vlt}"
-    fi
+    case "${RUSTDV_VERILATOR_MODE:-fast}" in
+      debug|inspect)
+        export RUSTDV_VERILATOR_CONTROL_FILE="${RUSTDV_VERILATOR_CONTROL_FILE:-$REPO_ROOT/sim/verilator-debug.vlt}"
+        ;;
+    esac
     "$REPO_ROOT/sim/run_verilator.sh" "$LIB" tinyalu "$BUILD/verilator" \
       "$REPO_ROOT/sim/hdl/timescale.v" "$REPO_ROOT/sim/hdl/tinyalu.sv"
     ;;

--- a/sim/run_verilator.sh
+++ b/sim/run_verilator.sh
@@ -6,6 +6,7 @@
 # RUSTDV_VERILATOR_MODE:
 #   fast       top-level DUT ports only (default)
 #   debug      selected internals from RUSTDV_VERILATOR_CONTROL_FILE + FST
+#   inspect    selected internals from RUSTDV_VERILATOR_CONTROL_FILE, no FST
 #   framework  all signals visible; regression probes only
 set -euo pipefail
 
@@ -119,11 +120,23 @@ case "$MODE" in
         fi
         export RUSTDV_FST="${RUSTDV_FST:-$BUILD/${TOP}.fst}"
         ;;
+    inspect)
+        CONTROL="${RUSTDV_VERILATOR_CONTROL_FILE:-}"
+        if [ -z "$CONTROL" ] || [ ! -f "$CONTROL" ]; then
+            echo "rustdv: inspect mode requires RUSTDV_VERILATOR_CONTROL_FILE=<file.vlt>" >&2
+            exit 2
+        fi
+        if [ -n "${RUSTDV_FST:-}" ]; then
+            echo "rustdv: FST tracing belongs to debug mode (set RUSTDV_VERILATOR_MODE=debug)" >&2
+            exit 2
+        fi
+        INPUTS+=("$CONTROL")
+        ;;
     framework)
         FLAGS+=(--public-flat-rw)
         ;;
     *)
-        echo "rustdv: unknown RUSTDV_VERILATOR_MODE '$MODE' (use fast|debug|framework)" >&2
+        echo "rustdv: unknown RUSTDV_VERILATOR_MODE '$MODE' (use fast|debug|inspect|framework)" >&2
         exit 2
         ;;
 esac


### PR DESCRIPTION
## Summary

- Add a transport-neutral service_read_only helper that runs synchronous work inside RustDV ReadOnly, after the Verilator host has reached its fixed point.
- Add an inspect Verilator mode for selected control-file VPI visibility without building or emitting an FST.
- Add focused real-Verilator regressions for settled reads, frozen simulation time during a bounded worker exchange, panic containment, resumed progress, and the no-waveform policy.

## Motivation

This is the small framework-side contract needed by external live-debug controllers such as rustdv-components issue #8. A controller can service signal requests on the simulator thread while time is frozen, then release normal simulation progress. The controller remains outside RustDV; this PR adds no MCP server, controller policy, or second scheduler.

The inspect mode provides selected internal VPI visibility for that workflow without paying the waveform cost of debug mode.

## Safety contract

A service wait must be bounded by wall-clock time or cooperatively cancellable. Simulation-time timeouts cannot fire while ReadOnly is held, and the API documents that RustDV cannot recover an arbitrary blocking closure.

## Validation

- sim-stable-point-verilator
- sim-inspect-verilator
- existing sim-debug-verilator
- existing sim-tinyalu-tb-verilator FAST path
- cargo test -p rustdv-sim -p rustdv -p framework_tests

All passed locally with Verilator 5.050.