### PR TITLE
Fix Verilator/VPI struct and top-module handling

### DIFF
--- a/output/regression/tests/sim-class-top-verilator/test.json
+++ b/output/regression/tests/sim-class-top-verilator/test.json
@@ -1,0 +1,19 @@
+{
+  "comment": "Verilator VPI discovery: a compilation-unit SystemVerilog class creates a synthetic *_Vclpkg top scope, but rustdv must select the requested module as the DUT.",
+  "cmd": ["bash", "rustdv/framework-tests/run.sh"],
+  "cwd": ".",
+  "skip_if_missing": "verilator",
+  "env": {
+    "SIM": "verilator",
+    "RUSTDV_TESTCASE": "vpi_class_top_scope_selects_dut",
+    "RUSTDV_TOP": "class_top",
+    "RUSTDV_HDL": "rustdv/framework-tests/hdl/class_top.sv"
+  },
+  "expect_exit": 0,
+  "timeout": 600,
+  "expect_in_output": [
+    "rustdv: found 1 test(s)",
+    "vpi_class_top_scope_selects_dut PASSED",
+    "REGRESSION: PASS"
+  ]
+}

--- a/output/regression/tests/sim-struct-ports-verilator/test.json
+++ b/output/regression/tests/sim-struct-ports-verilator/test.json
@@ -1,0 +1,19 @@
+{
+  "comment": "Verilator VPI discovery: aggregate structs used as top-level ports are vpiStructVar objects and must be available through rustdv's LogicHandle API.",
+  "cmd": ["bash", "rustdv/framework-tests/run.sh"],
+  "cwd": ".",
+  "skip_if_missing": "verilator",
+  "env": {
+    "SIM": "verilator",
+    "RUSTDV_TESTCASE": "vpi_struct_top_ports_are_logic",
+    "RUSTDV_TOP": "struct_ports_top",
+    "RUSTDV_HDL": "rustdv/framework-tests/hdl/struct_ports_top.sv"
+  },
+  "expect_exit": 0,
+  "timeout": 600,
+  "expect_in_output": [
+    "rustdv: found 1 test(s)",
+    "vpi_struct_top_ports_are_logic PASSED",
+    "REGRESSION: PASS"
+  ]
+}

--- a/rustdv/framework-tests/hdl/class_top.sv
+++ b/rustdv/framework-tests/hdl/class_top.sv
@@ -1,0 +1,19 @@
+// A compilation-unit class makes Verilator expose a synthetic *_Vclpkg
+// scope alongside the requested top module.  rustdv must not mistake that
+// implementation detail for the DUT.
+`timescale 1ns/1ns
+
+class class_top_transaction;
+   bit [7:0] payload;
+   static bit class_flag;
+endclass
+
+module class_top(
+   input  logic [7:0] data_i,
+   output logic [7:0] data_o
+);
+   initial class_top_transaction::class_flag = 0;
+   assign data_o = data_i ^ {8{class_top_transaction::class_flag}};
+
+   final $display("RTL FINAL: PASS");
+endmodule

--- a/rustdv/framework-tests/hdl/struct_ports_top.sv
+++ b/rustdv/framework-tests/hdl/struct_ports_top.sv
@@ -1,0 +1,18 @@
+// Structs used directly as top-level ports are vpiStructVar objects in the
+// simulator. rustdv must make those named port objects discoverable through
+// its ordinary LogicHandle API.
+`timescale 1ns/1ns
+
+typedef struct {
+   logic       valid;
+   logic [7:0] payload;
+} struct_port_t;
+
+module struct_ports_top(
+   input  struct_port_t request,
+   output struct_port_t response
+);
+   assign response = request;
+
+   final $display("RTL FINAL: PASS");
+endmodule

--- a/rustdv/framework-tests/run.sh
+++ b/rustdv/framework-tests/run.sh
@@ -3,16 +3,36 @@
 #
 # Usage:  framework-tests/run.sh [testcase-substring[,...]]
 #
-# With no argument every test in the crate runs. With one, RUSTDV_TESTCASE
-# selects a group by name prefix — `trig_`, `clock_`, `sig_`, `conc_`,
-# `elab_`, `runner_`, `callback_stress_` — which is how the regression gets
-# one entry per mechanism off a single build.
+# With no argument every test compatible with the default `probe` DUT runs.
+# With one, RUSTDV_TESTCASE selects a group by name prefix — `trig_`,
+# `clock_`, `sig_`, `conc_`, `elab_`, `runner_`, `callback_stress_`, or one
+# of the focused `vpi_` cases — which is how the regression gets one entry
+# per mechanism off a single build.
 #
 # Success criterion: prints "REGRESSION: PASS".
 set -euo pipefail
 cd "$(dirname "$0")"
 SIM="${SIM:-icarus}"
 REPO_ROOT="$(cd ../.. && pwd)"
+TOP="${RUSTDV_TOP:-}"
+HDL="${RUSTDV_HDL:-}"
+case "${1:-${RUSTDV_TESTCASE:-}}" in
+  *vpi_class_top_scope_selects_dut*)
+    TOP="${TOP:-class_top}"
+    HDL="${HDL:-$REPO_ROOT/rustdv/framework-tests/hdl/class_top.sv}"
+    ;;
+  *vpi_struct_top_ports_are_logic*)
+    TOP="${TOP:-struct_ports_top}"
+    HDL="${HDL:-$REPO_ROOT/rustdv/framework-tests/hdl/struct_ports_top.sv}"
+    ;;
+  *)
+    TOP="${TOP:-probe}"
+    HDL="${HDL:-$REPO_ROOT/rustdv/framework-tests/hdl/probe.sv}"
+    ;;
+esac
+if [[ "$HDL" != /* ]]; then
+    HDL="$REPO_ROOT/$HDL"
+fi
 
 # Scratch under one per-user root; see output/examples/sim-common/run_sim.sh
 # for why the uid is in the path.
@@ -28,18 +48,23 @@ export RUSTDV_RANDOM_SEED="${RUSTDV_RANDOM_SEED:-1}"
 export RUSTDV_RESULTS_XML="${RUSTDV_RESULTS_XML:-$BUILD/results.xml}"
 if [ $# -gt 0 ]; then
     export RUSTDV_TESTCASE="$1"
+elif [ -z "${RUSTDV_TESTCASE+x}" ] && [ "$TOP" = probe ]; then
+    # The vpi_* cases have purpose-built DUTs selected by their regression
+    # entries, so an unfiltered run against probe covers every compatible
+    # test rather than failing on ports probe intentionally does not have.
+    export RUSTDV_TESTCASE="trig_,clock_,sig_,conc_,elab_,runner_,callback_stress_"
 fi
 
 case "$SIM" in
   icarus)
     cp "$LIB" "$BUILD/framework_tests.vpi"
-    iverilog -g2012 -o "$BUILD/probe.vvp" -s probe hdl/probe.sv
-    vvp -M "$BUILD" -m framework_tests "$BUILD/probe.vvp"
+    iverilog -g2012 -o "$BUILD/$TOP.vvp" -s "$TOP" "$HDL"
+    vvp -M "$BUILD" -m framework_tests "$BUILD/$TOP.vvp"
     ;;
   verilator)
     export RUSTDV_VERILATOR_MODE=framework
-    "$REPO_ROOT/sim/run_verilator.sh" "$LIB" probe "$BUILD/verilator" \
-      "$REPO_ROOT/rustdv/framework-tests/hdl/probe.sv"
+    "$REPO_ROOT/sim/run_verilator.sh" "$LIB" "$TOP" "$BUILD/verilator-$TOP" \
+      "$HDL"
     ;;
   *)
     echo "unknown simulator: $SIM (use icarus|verilator)" >&2

--- a/rustdv/framework-tests/src/framework_tests.rs
+++ b/rustdv/framework-tests/src/framework_tests.rs
@@ -36,9 +36,12 @@
 //! | `elab_` | [`elaboration`] | unconnected ports fail before the run phase |
 //! | `runner_` | [`runner`] | timeouts, `expect_error`, per-test freshness |
 //! | `callback_stress_` | [`callback_lifecycle`] | fired one-shot handles reach an RSS plateau |
+//! | `vpi_` | [`vpi_regressions`] | Verilator class scopes and struct-valued top ports |
 //!
 //! The DUT is `hdl/probe.sv`: a clock, signals of known widths that nothing
 //! drives, and one counter so an edge trigger has something to trigger on.
+//! The two `vpi_` regressions use their own focused HDL tops because their
+//! hierarchy shapes are the behavior under test.
 
 use rustdv::prelude::*;
 
@@ -79,6 +82,7 @@ pub mod elaboration;
 pub mod runner;
 pub mod signals;
 pub mod triggers;
+pub mod vpi_regressions;
 
 /// How many simulator time steps make one nanosecond, measured rather than
 /// assumed.

--- a/rustdv/framework-tests/src/vpi_regressions.rs
+++ b/rustdv/framework-tests/src/vpi_regressions.rs
@@ -1,0 +1,60 @@
+//! Focused regressions for simulator-specific VPI object discovery.
+
+use rustdv::prelude::*;
+
+// A compilation-unit SystemVerilog class produces a synthetic Verilator
+// top-level scope whose name contains `_Vclpkg`.  The runner must construct
+// the context around the requested module, not that generated scope.
+#[rustdv::test]
+async fn vpi_class_top_scope_selects_dut(ctx: RustdvCtx) -> Result<(), TestError> {
+    let top_names: Vec<String> = rustdv::gpi::top_modules()
+        .into_iter()
+        .map(|top| top.name())
+        .collect();
+    rustdv::log::info(&format!("VPI TOPS: {top_names:?}"));
+    let dut = ctx.dut();
+    check!(
+        dut.name() == "class_top",
+        "selected {:?} as the DUT, not class_top",
+        dut.name()
+    );
+
+    let input = dut.signal("data_i")?;
+    let output = dut.signal("data_o")?;
+    input.set_u64(0xa5);
+    read_write().await;
+    read_only().await;
+    check!(
+        output.get_u64() == Ok(0xa5),
+        "class_top data path did not settle to 0xa5"
+    );
+    Ok(())
+}
+
+// Verilator reports aggregate struct ports as vpiStructVar rather than
+// vpiPort, vpiNet, or vpiReg. rustdv should still expose the named port
+// objects as LogicHandles. Verilator reports their aggregate width as zero,
+// so this deliberately tests discovery rather than packed-value operations.
+#[rustdv::test]
+async fn vpi_struct_top_ports_are_logic(ctx: RustdvCtx) -> Result<(), TestError> {
+    let dut = ctx.dut();
+    check!(
+        dut.name() == "struct_ports_top",
+        "selected {:?} as the DUT, not struct_ports_top",
+        dut.name()
+    );
+
+    let request = dut.signal("request")?;
+    let response = dut.signal("response")?;
+    check!(
+        request.full_name().ends_with(".request"),
+        "request resolved to {:?}",
+        request.full_name()
+    );
+    check!(
+        response.full_name().ends_with(".response"),
+        "response resolved to {:?}",
+        response.full_name()
+    );
+    Ok(())
+}

--- a/rustdv/rustdv-gpi-sys/src/rustdv_gpi_sys.rs
+++ b/rustdv/rustdv-gpi-sys/src/rustdv_gpi_sys.rs
@@ -55,6 +55,7 @@ pub const vpiShortIntVar: PLI_INT32 = 611;
 pub const vpiIntVar: PLI_INT32 = 612;
 pub const vpiByteVar: PLI_INT32 = 614;
 pub const vpiEnumVar: PLI_INT32 = 617;
+pub const vpiStructVar: PLI_INT32 = 618;
 pub const vpiBitVar: PLI_INT32 = 620;
 
 // ---------------------------------------------------------------------------

--- a/rustdv/rustdv-gpi/src/rustdv_gpi.rs
+++ b/rustdv/rustdv-gpi/src/rustdv_gpi.rs
@@ -124,7 +124,7 @@ impl AnyHandle {
             sys::vpiModule => AnyHandle::Hierarchy(HierarchyHandle { h }),
             sys::vpiNet | sys::vpiReg | sys::vpiIntegerVar | sys::vpiPort | sys::vpiMemory
             | sys::vpiLongIntVar | sys::vpiShortIntVar | sys::vpiIntVar | sys::vpiByteVar
-            | sys::vpiEnumVar | sys::vpiBitVar => {
+            | sys::vpiEnumVar | sys::vpiStructVar | sys::vpiBitVar => {
                 // Signal width is immutable for the lifetime of a VPI
                 // object. Cache it at discovery so every value read/write
                 // does not pay for another vpi_get(vpiSize) crossing.
@@ -402,9 +402,16 @@ pub fn top_modules() -> Vec<HierarchyHandle> {
     out
 }
 
-/// The first top-level module (the DUT in single-top designs).
+/// The first non-class/non-package top-level module (the DUT in single-top 
+/// designs).
 pub fn top_module() -> Result<HierarchyHandle, HandleError> {
-    top_modules().into_iter().next().ok_or(HandleError::NoTopModule)
+    let modules = top_modules();
+    modules
+        .iter()
+        .copied()
+        .find(|module| !module.name().contains("_Vclpkg"))
+        .or_else(|| modules.into_iter().next())
+        .ok_or(HandleError::NoTopModule)
 }
 
 // ===========================================================================


### PR DESCRIPTION
Add structs as supported VPI objects, and handles a case where RustDV incorrectly identifies a class (from Verilator) as a valid top-level.