### PR TITLE
Support additional integer signal types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "framework_tests"
 version = "0.1.0"
 dependencies = [
@@ -28,6 +34,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -64,6 +98,7 @@ dependencies = [
 name = "rustdv-gpi"
 version = "0.2.0"
 dependencies = [
+ "num-bigint",
  "rustdv-gpi-sys",
  "rustdv-vpi-stubs",
 ]

--- a/book-pdf/chapter-notes.md
+++ b/book-pdf/chapter-notes.md
@@ -135,7 +135,7 @@ explain, and explaining one would import a history the book does not have.
 |---|---|---|
 | 15 | `ch15-async-await-executor` | 2 listings. **The prelude debt lands here or just before** — this is where rustdv's surface first appears (`FABLE.md`, "Two writing debts"). |
 | 16 | `ch16-tasks-queues` | 15 listings. |
-| 17 | `ch17-simulating-with-rustdv-sim` | 6 listings. Candidate home for the rustdv catalogue if you fold it in rather than adding a chapter. |
+| 17 | `ch17-simulating-with-rustdv-sim` | 6 listings. Candidate home for the rustdv catalogue if you fold it in rather than adding a chapter. Signal-API audit (2026-08-30): logic-specific access is `get_logic` / `set_logic` / `set_logic_now`; no manuscript or README example used the retired `get` / `set` / `set_now` spellings, and the documented `get_u64` / `set_u64` names are unchanged. |
 | 18 | `ch18-basic-testbench-1.0` | 11 listings. |
 | 19 | `ch19-tinyalubfm` | 6 listings. **There is no software clock.** The RTL self-clocks and the BFM only waits on edges. `Clock` is taught once, as a cocotb feature; chapters must stop opening with `Clock::new(...)`. The reason is emulation: a BFM that waits on edges ports to a transactor unchanged, one that drives them does not. |
 | 20 | `ch20-struct-based-testbench-2.0` | 11 listings. TB 2.0. **This is a destination, not a stepping stone** — a reader must be able to write a complete, useful testbench with a DUT handle and signals and no components at all. If Part II reads as training wheels for Part III, the learning-curve objection wins. |
@@ -372,3 +372,5 @@ traits because `PartialEq` does not promise `a == a` — IEEE 754 says NaN equal
 nothing — and `Eq` adds that promise. It bites a verification engineer in one
 specific place: `HashSet` requires `Eq`, so a transaction carrying a *measured*
 value like a float delay cannot be a coverage key.
+
+- API maintenance: `LogicArray::bit(index)` is replaced by `array[index]`, preserving `Option<Logic>` and `None` for out-of-bounds access. No manuscript call sites required updates.

--- a/output/examples/Cargo.lock
+++ b/output/examples/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "ch01_why_rust"
 version = "0.1.0"
 
@@ -248,6 +254,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,6 +315,7 @@ dependencies = [
 name = "rustdv-gpi"
 version = "0.2.0"
 dependencies = [
+ "num-bigint",
  "rustdv-gpi-sys",
 ]
 

--- a/rustdv/framework-tests/compile-fail/eq_on_a_float/Cargo.lock
+++ b/rustdv/framework-tests/compile-fail/eq_on_a_float/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "cf_eq_on_a_float"
 version = "0.1.0"
 dependencies = [
@@ -27,6 +33,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -63,6 +97,7 @@ dependencies = [
 name = "rustdv-gpi"
 version = "0.2.0"
 dependencies = [
+ "num-bigint",
  "rustdv-gpi-sys",
 ]
 

--- a/rustdv/framework-tests/compile-fail/export_interface_mismatch/Cargo.lock
+++ b/rustdv/framework-tests/compile-fail/export_interface_mismatch/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "cf_export_interface_mismatch"
 version = "0.1.0"
 dependencies = [
@@ -27,6 +33,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -63,6 +97,7 @@ dependencies = [
 name = "rustdv-gpi"
 version = "0.2.0"
 dependencies = [
+ "num-bigint",
  "rustdv-gpi-sys",
 ]
 

--- a/rustdv/framework-tests/compile-fail/misspelled_port_name/Cargo.lock
+++ b/rustdv/framework-tests/compile-fail/misspelled_port_name/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "cf_misspelled_port_name"
 version = "0.1.0"
 dependencies = [
@@ -27,6 +33,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -63,6 +97,7 @@ dependencies = [
 name = "rustdv-gpi"
 version = "0.2.0"
 dependencies = [
+ "num-bigint",
  "rustdv-gpi-sys",
 ]
 

--- a/rustdv/framework-tests/compile-fail/port_attr_on_non_port/Cargo.lock
+++ b/rustdv/framework-tests/compile-fail/port_attr_on_non_port/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "cf_port_attr_on_non_port"
 version = "0.1.0"
 dependencies = [
@@ -27,6 +33,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -63,6 +97,7 @@ dependencies = [
 name = "rustdv-gpi"
 version = "0.2.0"
 dependencies = [
+ "num-bigint",
  "rustdv-gpi-sys",
 ]
 

--- a/rustdv/framework-tests/compile-fail/use_after_finish_item/Cargo.lock
+++ b/rustdv/framework-tests/compile-fail/use_after_finish_item/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "cf_use_after_finish_item"
 version = "0.1.0"
 dependencies = [
@@ -27,6 +33,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93e7820bc0a80a0238e650327316f929ba18d5be054b647490a3a6a339f3e7c0"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -63,6 +97,7 @@ dependencies = [
 name = "rustdv-gpi"
 version = "0.2.0"
 dependencies = [
+ "num-bigint",
  "rustdv-gpi-sys",
 ]
 

--- a/rustdv/framework-tests/hdl/probe.sv
+++ b/rustdv/framework-tests/hdl/probe.sv
@@ -15,6 +15,10 @@ module probe;
    // read-back that differs from the write is the framework's doing.
    logic [7:0]  byte_sig;
    logic [15:0] word_sig;
+   logic [31:0] dword_sig;
+   logic [63:0] qword_sig;
+   logic [127:0] u128_sig;
+   logic [159:0] bigint_sig;
    logic [3:0]  nibble;
    logic        flag;
 
@@ -46,7 +50,8 @@ module probe;
    // "no object named 'byte_sig' in scope 'probe'". Reading them all into one
    // wire nobody uses keeps them alive without driving them, which is the
    // whole point of declaring them.
-   wire keep_alive = ^{byte_sig, word_sig, nibble, flag, comb_in, comb_out,
+   wire keep_alive = ^{byte_sig, word_sig, dword_sig, qword_sig, u128_sig,
+                       bigint_sig, nibble, flag, comb_in, comb_out,
                        rtl_event_request, rtl_event_done,
                        never_driven, never_driven_bus};
 

--- a/rustdv/framework-tests/src/signals.rs
+++ b/rustdv/framework-tests/src/signals.rs
@@ -14,6 +14,10 @@ async fn sig_widths_match_the_design(ctx: RustdvCtx) -> Result<(), TestError> {
     for (name, want) in [
         ("byte_sig", 8u32),
         ("word_sig", 16),
+        ("dword_sig", 32),
+        ("qword_sig", 64),
+        ("u128_sig", 128),
+        ("bigint_sig", 160),
         ("nibble", 4),
         ("flag", 1),
     ] {
@@ -42,6 +46,53 @@ async fn sig_round_trips(ctx: RustdvCtx) -> Result<(), TestError> {
             "{name} read back {got:#x} after writing {value:#x}"
         );
     }
+    Ok(())
+}
+
+// Every typed scheduled-write path reaches VPI, and every matching getter
+// reconstructs the same value from the simulator.
+#[rustdv::test]
+async fn sig_typed_values_round_trip(ctx: RustdvCtx) -> Result<(), TestError> {
+    let dut = ctx.dut();
+    let flag = dut.signal("flag")?;
+    let byte = dut.signal("byte_sig")?;
+    let word = dut.signal("word_sig")?;
+    let dword = dut.signal("dword_sig")?;
+    let qword = dut.signal("qword_sig")?;
+    let wide = dut.signal("u128_sig")?;
+    let arbitrary = dut.signal("bigint_sig")?;
+
+    let bigint = BigUint::from_slice(&[
+        0x7654_3210,
+        0xfedc_ba98,
+        0x89ab_cdef,
+        0x0123_4567,
+        0xa5a5_5a5a,
+    ]);
+    let u128_value = 0x0123_4567_89ab_cdef_fedc_ba98_7654_3210;
+
+    flag.set_bool(true);
+    byte.set_u8(0xa5);
+    word.set_u16(0xa5b6);
+    dword.set_u32(0xa5b6_c7d8);
+    qword.set_u64(0x0123_4567_89ab_cdef);
+    wide.set_u128(u128_value);
+    arbitrary.set_bigint(&bigint);
+    read_write().await;
+
+    check!(flag.get_bool() == Ok(true), "bool did not round-trip");
+    check!(byte.get_u8() == Ok(0xa5), "u8 did not round-trip");
+    check!(word.get_u16() == Ok(0xa5b6), "u16 did not round-trip");
+    check!(dword.get_u32() == Ok(0xa5b6_c7d8), "u32 did not round-trip");
+    check!(
+        qword.get_u64() == Ok(0x0123_4567_89ab_cdef),
+        "u64 did not round-trip"
+    );
+    check!(wide.get_u128() == Ok(u128_value), "u128 did not round-trip");
+    check!(
+        arbitrary.get_bigint() == Ok(bigint),
+        "BigUint did not round-trip"
+    );
     Ok(())
 }
 
@@ -76,10 +127,11 @@ async fn sig_x_is_an_error_not_a_zero(ctx: RustdvCtx) -> Result<(), TestError> {
         x.get_u64().is_err(),
         "an undriven bit converted to an integer"
     );
+    let x_binstr = x.get_binstr()?;
     check!(
-        x.get_binstr().contains('x'),
+        x_binstr.contains('x'),
         "an undriven bit reads as {:?}",
-        x.get_binstr()
+        x_binstr
     );
     check!(
         !x.is_high() && !x.is_low(),
@@ -91,10 +143,11 @@ async fn sig_x_is_an_error_not_a_zero(ctx: RustdvCtx) -> Result<(), TestError> {
         bus.get_u64().is_err(),
         "an undriven bus converted to an integer"
     );
+    let bus_binstr = bus.get_binstr()?;
     check!(
-        bus.get_binstr().chars().all(|c| c == 'x'),
+        bus_binstr.chars().all(|c| c == 'x'),
         "an undriven bus reads as {:?}",
-        bus.get_binstr()
+        bus_binstr
     );
 
     // And the escape hatch the book teaches still works.
@@ -126,17 +179,18 @@ async fn sig_partial_x_is_still_an_error(ctx: RustdvCtx) -> Result<(), TestError
         !arr.is_resolvable(),
         "a pattern containing x claimed to be resolvable"
     );
-    sig.set(&arr);
+    sig.set_logic(&arr);
     read_write().await;
     check!(
         sig.get_u64().is_err(),
         "a byte with one x bit converted to {:?}",
         sig.get_u64()
     );
+    let sig_binstr = sig.get_binstr()?;
     check!(
-        sig.get_binstr().contains('x'),
+        sig_binstr.contains('x'),
         "the x bit vanished: {:?}",
-        sig.get_binstr()
+        sig_binstr
     );
     Ok(())
 }

--- a/rustdv/rustdv-gpi/Cargo.toml
+++ b/rustdv/rustdv-gpi/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/rustdv/rustdv"
 path = "src/rustdv_gpi.rs"
 
 [dependencies]
+num-bigint = "0.5.1"
 rustdv-gpi-sys = { path = "../rustdv-gpi-sys", version = "0.2.0" }
 
 [dev-dependencies]

--- a/rustdv/rustdv-gpi/src/rustdv_gpi.rs
+++ b/rustdv/rustdv-gpi/src/rustdv_gpi.rs
@@ -25,7 +25,8 @@ use std::fmt;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::rc::Rc;
 
-use rustdv_gpi_sys as sys;
+pub use num_bigint::BigUint;
+use rustdv_gpi_sys::{self as sys, t_vpi_vecval};
 
 // Test executables need vpi_* symbol definitions (the simulator provides
 // them for the real cdylib) — see rustdv-vpi-stubs.
@@ -34,6 +35,8 @@ use rustdv_vpi_stubs as _;
 
 pub mod value;
 pub use value::{Logic, LogicArray};
+pub mod util;
+pub use util::ToVpiWords;
 
 // ===========================================================================
 // Errors
@@ -79,6 +82,8 @@ impl std::error::Error for HandleError {}
 pub enum ValueError {
     /// Value contains x/z bits and was asked for as an integer.
     FourState(String),
+    /// The simulator did not supply the requested value representation.
+    Unavailable,
     Width {
         want: u32,
         have: usize,
@@ -89,6 +94,7 @@ impl fmt::Display for ValueError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ValueError::FourState(s) => write!(f, "value '{s}' has x/z bits"),
+            ValueError::Unavailable => write!(f, "simulator did not return a vector value"),
             ValueError::Width { want, have } => {
                 write!(f, "width mismatch: want {want}, have {have}")
             }
@@ -285,38 +291,11 @@ impl LogicHandle {
         self.width
     }
 
-    /// Current value as a binary string, e.g. "0101", "xxxx".
-    pub fn get_binstr(&self) -> String {
-        let mut val = sys::t_vpi_value {
-            format: sys::vpiBinStrVal,
-            value: sys::u_vpi_value_union { integer: 0 },
-        };
-        unsafe {
-            sys::vpi_get_value(self.h.0, &mut val);
-            let p = val.value.str_;
-            if p.is_null() {
-                String::new()
-            } else {
-                CStr::from_ptr(p).to_string_lossy().into_owned()
-            }
-        }
-    }
-
-    /// Current value as a LogicArray (4-state).
-    pub fn get(&self) -> LogicArray {
-        LogicArray::from_binstr(&self.get_binstr())
-    }
-
-    /// Current value as u64; `Err` if any bit is x/z (design-doc §0.6:
-    /// conversion failures are Results, not exceptions).
-    pub fn get_u64(&self) -> Result<u64, ValueError> {
-        let width = self.size().max(1);
-        if width > 64 {
-            return Err(ValueError::Width {
-                want: width,
-                have: 64,
-            });
-        }
+    /// Current value as a slice of VPI vector words. `Err` if the simulator
+    /// did not supply a vector representation (design-doc §0.6: conversion
+    /// failures are Results, not exceptions). Handles `unsafe` and null pointer
+    /// checks internally.
+    fn get_vpi_words(&self) -> Result<&[sys::t_vpi_vecval], ValueError> {
         let mut val = sys::t_vpi_value {
             format: sys::vpiVectorVal,
             value: sys::u_vpi_value_union {
@@ -327,92 +306,276 @@ impl LogicHandle {
             sys::vpi_get_value(self.h.0, &mut val);
             let words = val.value.vector;
             if words.is_null() {
-                return Ok(0);
+                return Err(ValueError::Unavailable);
             }
-            let word_count = width.div_ceil(32) as usize;
-            let mut result = 0u64;
-            for index in 0..word_count {
-                let word = *words.add(index);
-                let used_bits = if index + 1 == word_count && !width.is_multiple_of(32) {
-                    width % 32
-                } else {
-                    32
-                };
-                let mask = if used_bits == 32 {
-                    u32::MAX
-                } else {
-                    (1u32 << used_bits) - 1
-                };
-                if word.bval & mask != 0 {
-                    return Err(ValueError::FourState(self.get_binstr()));
-                }
-                result |= ((word.aval & mask) as u64) << (index * 32);
-            }
-            Ok(result)
+            let word_count = self.size().div_ceil(32) as usize;
+            Ok(std::slice::from_raw_parts(words, word_count))
         }
     }
 
-    fn put_binstr_flags(&self, bin: &str, flags: i32) {
-        let c = CString::new(bin).expect("NUL in binstr");
-        let mut val = sys::t_vpi_value {
-            format: sys::vpiBinStrVal,
-            value: sys::u_vpi_value_union {
-                str_: c.as_ptr() as *mut _,
-            },
-        };
-        unsafe {
-            sys::vpi_put_value(self.h.0, &mut val, std::ptr::null_mut(), flags);
-        }
-    }
-
-    fn put_vector_words(&self, words: &mut [sys::t_vpi_vecval]) {
-        let mut val = sys::t_vpi_value {
-            format: sys::vpiVectorVal,
-            value: sys::u_vpi_value_union {
-                vector: words.as_mut_ptr(),
-            },
-        };
-        unsafe {
-            sys::vpi_put_value(self.h.0, &mut val, std::ptr::null_mut(), sys::vpiNoDelay);
-        }
-    }
-
-    /// Immediate (NoDelay) write of an integer value, zero-extended /
-    /// truncated to the signal width. This is the "setimmediatevalue"
-    /// analog; scheduled writes are layered above (design-doc §4.1(4)).
-    pub fn set_u64_now(&self, v: u64) {
-        let width = self.size().max(1);
-        let word_count = width.div_ceil(32) as usize;
-        let mut words = if word_count <= 2 {
-            let words = [
-                sys::t_vpi_vecval {
-                    aval: v as u32,
-                    bval: 0,
-                },
-                sys::t_vpi_vecval {
-                    aval: (v >> 32) as u32,
-                    bval: 0,
-                },
-            ];
-            words[..word_count].to_vec()
+    /// Masks one VPI vector word to the signal width. `Err` if any used bit is
+    /// x/z (design-doc §0.6: conversion failures are Results, not exceptions).
+    ///
+    /// # Arguments
+    ///
+    /// * `word` - Individual VPI vector word from [`Self::get_vpi_words`].
+    /// * `width` - Width of the entire signal in bits.
+    /// * `last` - Whether `word` is the signal's final VPI vector word.
+    fn get_vpi_word(&self, word: &t_vpi_vecval, width: u32, last: bool) -> Result<u32, ValueError> {
+        let used_bits = if last && !width.is_multiple_of(32) {
+            width % 32
         } else {
-            let mut words = vec![sys::t_vpi_vecval::default(); word_count];
-            words[0].aval = v as u32;
-            words[1].aval = (v >> 32) as u32;
-            words
+            32
         };
-        if !width.is_multiple_of(32) {
-            let mask = (1u32 << (width % 32)) - 1;
-            let last = words.last_mut().expect("positive width has a vector word");
+        let mask = if used_bits == 32 {
+            u32::MAX
+        } else {
+            (1u32 << used_bits) - 1
+        };
+        if word.bval & mask != 0 {
+            return Err(ValueError::FourState(self.get_logic()?.to_binstr()));
+        }
+        Ok(word.aval & mask)
+    }
+
+    /// Check that the signal width is at most `want` bits. Returns `Err` if
+    /// the signal is wider than `want` (design-doc §0.6: conversion failures
+    /// are Results, not exceptions).
+    fn check_size(&self, want: u32) -> Result<(), ValueError> {
+        if self.size() > want {
+            return Err(ValueError::Width {
+                want,
+                have: self.size() as usize,
+            });
+        }
+        Ok(())
+    }
+
+    /// Current value as bool; `Err` if the signal is wider than one bit or its
+    /// value is x/z (design-doc §0.6: conversion failures are Results, not
+    /// exceptions).
+    pub fn get_bool(&self) -> Result<bool, ValueError> {
+        self.check_size(1)?;
+        Ok(self.get_vpi_word(&self.get_vpi_words()?[0], self.size(), true)? != 0)
+    }
+
+    /// Current value as u8; `Err` if any bit is x/z (design-doc §0.6:
+    /// conversion failures are Results, not exceptions).
+    pub fn get_u8(&self) -> Result<u8, ValueError> {
+        self.check_size(u8::BITS)?;
+        Ok(self.get_vpi_word(&self.get_vpi_words()?[0], self.size(), true)? as u8)
+    }
+
+    /// Current value as u16; `Err` if any bit is x/z (design-doc §0.6:
+    /// conversion failures are Results, not exceptions).
+    pub fn get_u16(&self) -> Result<u16, ValueError> {
+        self.check_size(u16::BITS)?;
+        Ok(self.get_vpi_word(&self.get_vpi_words()?[0], self.size(), true)? as u16)
+    }
+
+    /// Current value as u32; `Err` if any bit is x/z (design-doc §0.6:
+    /// conversion failures are Results, not exceptions).
+    pub fn get_u32(&self) -> Result<u32, ValueError> {
+        self.check_size(u32::BITS)?;
+        self.get_vpi_word(&self.get_vpi_words()?[0], self.size(), true)
+    }
+
+    /// Current value as u64; `Err` if any bit is x/z (design-doc §0.6:
+    /// conversion failures are Results, not exceptions).
+    pub fn get_u64(&self) -> Result<u64, ValueError> {
+        self.check_size(u64::BITS)?;
+        let words = self.get_vpi_words()?;
+        let mut result = 0;
+        for (index, word) in words.iter().enumerate() {
+            let word = self.get_vpi_word(word, self.size(), index + 1 == words.len())?;
+            result |= (word as u64) << (index * 32);
+        }
+        Ok(result)
+    }
+
+    /// Current value as u128; `Err` if any bit is x/z (design-doc §0.6:
+    /// conversion failures are Results, not exceptions).
+    pub fn get_u128(&self) -> Result<u128, ValueError> {
+        self.check_size(u128::BITS)?;
+        let words = self.get_vpi_words()?;
+        let mut result = 0;
+        for (index, word) in words.iter().enumerate() {
+            let word = self.get_vpi_word(word, self.size(), index + 1 == words.len())?;
+            result |= (word as u128) << (index * 32);
+        }
+        Ok(result)
+    }
+
+    /// Current value as an unsigned arbitrary-precision integer; `Err` if
+    /// any bit is x/z.
+    pub fn get_bigint(&self) -> Result<BigUint, ValueError> {
+        let words = self.get_vpi_words()?;
+        let mut digits = Vec::with_capacity(words.len());
+        for (index, word) in words.iter().enumerate() {
+            digits.push(self.get_vpi_word(word, self.size(), index + 1 == words.len())?);
+        }
+        Ok(BigUint::from_slice(&digits))
+    }
+
+    /// Current value as a LogicArray (4-state). `Err` if the simulator does
+    /// not supply a VPI vector representation.
+    pub fn get_logic(&self) -> Result<LogicArray, ValueError> {
+        let words = self.get_vpi_words()?;
+        let words: Vec<(u32, u32)> = words.iter().map(|word| (word.aval, word.bval)).collect();
+        Ok(LogicArray::from_vpi_words(&words, self.size() as usize))
+    }
+
+    /// Mask unused bits in the final VPI vector word to the signal width.
+    fn mask_vector_words(&self, words: &mut [sys::t_vpi_vecval]) {
+        if !self.size().is_multiple_of(32) {
+            let mask = (1u32 << (self.size() % 32)) - 1;
+            let last = words.last_mut().expect("partial width has a vector word");
             last.aval &= mask;
             last.bval &= mask;
         }
-        self.put_vector_words(&mut words);
     }
 
-    /// Immediate write of a 4-state value.
-    pub fn set_now(&self, v: &LogicArray) {
-        self.put_binstr_flags(&v.to_binstr(), sys::vpiNoDelay);
+    /// Resize vector words to the signal width and pass them to
+    /// `vpi_put_value`. Handles unsafe usage internally, i.e. words can be any
+    /// length and the vpi call is still safe.
+    fn set_vector_words(&self, words: &mut [sys::t_vpi_vecval], flags: i32) {
+        let word_count = self.size().div_ceil(32) as usize;
+        if words.len() == word_count {
+            // Word length matches, just mask the final word to the signal width
+            self.mask_vector_words(words);
+            unsafe {
+                let mut vpi_value = sys::t_vpi_value {
+                    format: sys::vpiVectorVal,
+                    value: sys::u_vpi_value_union {
+                        vector: words.as_mut_ptr(),
+                    },
+                };
+                sys::vpi_put_value(self.h.0, &mut vpi_value, std::ptr::null_mut(), flags);
+            }
+        } else if words.len() > word_count {
+            // Word length is greater, truncate to the signal width and mask the
+            // final word
+            let words = &mut words[..word_count];
+            self.mask_vector_words(words);
+            unsafe {
+                let mut vpi_value = sys::t_vpi_value {
+                    format: sys::vpiVectorVal,
+                    value: sys::u_vpi_value_union {
+                        vector: words.as_mut_ptr(),
+                    },
+                };
+                sys::vpi_put_value(self.h.0, &mut vpi_value, std::ptr::null_mut(), flags);
+            }
+        } else {
+            // Word length is less, pad with zeros to the signal width
+            let mut words = words.to_vec();
+            words.resize(word_count, sys::t_vpi_vecval::default());
+            unsafe {
+                let mut vpi_value = sys::t_vpi_value {
+                    format: sys::vpiVectorVal,
+                    value: sys::u_vpi_value_union {
+                        vector: words.as_mut_ptr(),
+                    },
+                };
+                sys::vpi_put_value(self.h.0, &mut vpi_value, std::ptr::null_mut(), flags);
+            }
+        }
+    }
+
+    /// Write a bool with the supplied VPI flag, zero-extended to the signal
+    /// width.
+    pub fn set_bool(&self, v: bool, flags: i32) {
+        self.set_vector_words(&mut v.to_vpi_words(), flags);
+    }
+
+    /// Immediate (NoDelay) write of a bool.
+    pub fn set_bool_now(&self, v: bool) {
+        self.set_bool(v, sys::vpiNoDelay);
+    }
+
+    /// Write a u8 with the supplied VPI flag, zero-extended / truncated to the
+    /// signal width.
+    pub fn set_u8(&self, v: u8, flags: i32) {
+        self.set_vector_words(&mut v.to_vpi_words(), flags);
+    }
+
+    /// Immediate (NoDelay) write of a u8.
+    pub fn set_u8_now(&self, v: u8) {
+        self.set_u8(v, sys::vpiNoDelay);
+    }
+
+    /// Write a u16 with the supplied VPI flag, zero-extended / truncated to
+    /// the signal width.
+    pub fn set_u16(&self, v: u16, flags: i32) {
+        self.set_vector_words(&mut v.to_vpi_words(), flags);
+    }
+
+    /// Immediate (NoDelay) write of a u16.
+    pub fn set_u16_now(&self, v: u16) {
+        self.set_u16(v, sys::vpiNoDelay);
+    }
+
+    /// Write a u32 with the supplied VPI flag, zero-extended / truncated to
+    /// the signal width.
+    pub fn set_u32(&self, v: u32, flags: i32) {
+        self.set_vector_words(&mut v.to_vpi_words(), flags);
+    }
+
+    /// Immediate (NoDelay) write of a u32.
+    pub fn set_u32_now(&self, v: u32) {
+        self.set_u32(v, sys::vpiNoDelay);
+    }
+
+    /// Write a u64 with the supplied VPI flag, zero-extended / truncated to
+    /// the signal width.
+    pub fn set_u64(&self, v: u64, flags: i32) {
+        self.set_vector_words(&mut v.to_vpi_words(), flags);
+    }
+
+    /// Immediate (NoDelay) write of a u64.
+    pub fn set_u64_now(&self, v: u64) {
+        self.set_u64(v, sys::vpiNoDelay);
+    }
+
+    /// Write a u128 with the supplied VPI flag, zero-extended / truncated to
+    /// the signal width.
+    pub fn set_u128(&self, v: u128, flags: i32) {
+        self.set_vector_words(&mut v.to_vpi_words(), flags);
+    }
+
+    /// Immediate (NoDelay) write of a u128.
+    pub fn set_u128_now(&self, v: u128) {
+        self.set_u128(v, sys::vpiNoDelay);
+    }
+
+    /// Write an arbitrary-precision integer with the supplied VPI flag,
+    /// zero-extended / truncated to the signal width.
+    pub fn set_bigint(&self, v: &BigUint, flags: i32) {
+        let mut words: Vec<sys::t_vpi_vecval> = v
+            .iter_u32_digits()
+            .map(|aval| sys::t_vpi_vecval { aval, bval: 0 })
+            .collect();
+        self.set_vector_words(&mut words, flags);
+    }
+
+    /// Immediate (NoDelay) write of an arbitrary-precision integer.
+    pub fn set_bigint_now(&self, v: &BigUint) {
+        self.set_bigint(v, sys::vpiNoDelay);
+    }
+
+    /// Write a 4-state value with the supplied VPI flag.
+    pub fn set_logic(&self, v: &LogicArray, flags: i32) {
+        let mut words: Vec<sys::t_vpi_vecval> = v
+            .to_vpi_words()
+            .into_iter()
+            .map(|(aval, bval)| sys::t_vpi_vecval { aval, bval })
+            .collect();
+        self.set_vector_words(&mut words, flags);
+    }
+
+    /// Immediate (NoDelay) write of a 4-state value.
+    pub fn set_logic_now(&self, v: &LogicArray) {
+        self.set_logic(v, sys::vpiNoDelay);
     }
 }
 
@@ -768,6 +931,40 @@ pub fn register_end_of_simulation(f: Box<dyn FnOnce()>) -> CallbackHandle {
 }
 
 #[cfg(test)]
+mod vpi_word_tests {
+    use super::*;
+
+    fn assert_single_word<T: ToVpiWords<1>>(value: T, expected: u32) {
+        let words = value.to_vpi_words();
+        assert_eq!(words[0].aval, expected);
+        assert_eq!(words[0].bval, 0);
+    }
+
+    #[test]
+    fn scalar_values_convert_to_one_vpi_word() {
+        assert_single_word(false, 0);
+        assert_single_word(true, 1);
+        assert_single_word(0xa5u8, 0xa5);
+        assert_single_word(0xa5b6u16, 0xa5b6);
+        assert_single_word(0xa5b6_c7d8u32, 0xa5b6_c7d8);
+    }
+
+    #[test]
+    fn wide_values_convert_in_least_significant_word_first_order() {
+        let words = 0x0123_4567_89ab_cdefu64.to_vpi_words();
+        assert_eq!(words.map(|word| word.aval), [0x89ab_cdef, 0x0123_4567]);
+        assert!(words.iter().all(|word| word.bval == 0));
+
+        let words = 0x0123_4567_89ab_cdef_fedc_ba98_7654_3210u128.to_vpi_words();
+        assert_eq!(
+            words.map(|word| word.aval),
+            [0x7654_3210, 0xfedc_ba98, 0x89ab_cdef, 0x0123_4567]
+        );
+        assert!(words.iter().all(|word| word.bval == 0));
+    }
+}
+
+#[cfg(test)]
 mod callback_tests {
     use super::*;
     use std::cell::Cell;
@@ -867,7 +1064,7 @@ mod handle_tests {
         let signal = make_signal(
             8,
             &[sys::t_vpi_vecval {
-                aval: 0x5a,
+                aval: 0x5e,
                 bval: 0x04,
             }],
             "01011x10",
@@ -880,7 +1077,111 @@ mod handle_tests {
     }
 
     #[test]
+    fn logic_array_read_uses_vpi_vector_words() {
+        let signal = make_signal(
+            4,
+            &[sys::t_vpi_vecval {
+                aval: 0b0110,
+                bval: 0b0011,
+            }],
+            "0000",
+        );
+
+        assert_eq!(signal.get_logic().unwrap().to_binstr(), "01xz");
+    }
+
+    #[test]
+    fn vector_read_returns_numeric_zero_from_a_vector_word() {
+        let signal = make_signal(8, &[sys::t_vpi_vecval { aval: 0, bval: 0 }], "00000000");
+
+        assert_eq!(signal.get_u64(), Ok(0));
+    }
+
+    #[test]
+    fn bool_read_converts_single_bit_values() {
+        let low = make_signal(1, &[sys::t_vpi_vecval { aval: 0, bval: 0 }], "0");
+        assert_eq!(low.get_bool(), Ok(false));
+
+        let high = make_signal(1, &[sys::t_vpi_vecval { aval: 1, bval: 0 }], "1");
+        assert_eq!(high.get_bool(), Ok(true));
+    }
+
+    #[test]
+    fn bool_read_rejects_wide_and_four_state_values() {
+        let wide = make_signal(2, &[sys::t_vpi_vecval { aval: 1, bval: 0 }], "01");
+        assert_eq!(wide.get_bool(), Err(ValueError::Width { want: 1, have: 2 }));
+
+        let unknown = make_signal(1, &[sys::t_vpi_vecval { aval: 1, bval: 1 }], "x");
+        assert_eq!(
+            unknown.get_bool(),
+            Err(ValueError::FourState("x".to_owned()))
+        );
+    }
+
+    #[test]
+    fn vector_read_reports_an_unavailable_vpi_result() {
+        let signal = make_signal(8, &[sys::t_vpi_vecval { aval: 0, bval: 0 }], "00000000");
+        rustdv_vpi_stubs::make_vector_value_unavailable();
+
+        assert_eq!(signal.get_u64(), Err(ValueError::Unavailable));
+        assert_eq!(signal.get_bigint(), Err(ValueError::Unavailable));
+        assert_eq!(signal.get_logic(), Err(ValueError::Unavailable));
+    }
+
+    #[test]
+    fn bigint_read_supports_values_wider_than_u64() {
+        let signal = make_signal(
+            70,
+            &[
+                sys::t_vpi_vecval {
+                    aval: 0x89ab_cdef,
+                    bval: 0,
+                },
+                sys::t_vpi_vecval {
+                    aval: 0x0123_4567,
+                    bval: 0,
+                },
+                sys::t_vpi_vecval {
+                    aval: 0xffff_ffea,
+                    bval: 0xffff_ffc0,
+                },
+            ],
+            "1010100000000100100011010001010110011110001001101010111100110111101111",
+        );
+
+        assert_eq!(
+            signal.get_bigint().map(|value| value.to_str_radix(16)),
+            Ok("2a0123456789abcdef".to_owned())
+        );
+    }
+
+    #[test]
+    fn bigint_read_reports_xz_in_used_bits() {
+        let signal = make_signal(
+            65,
+            &[
+                sys::t_vpi_vecval::default(),
+                sys::t_vpi_vecval::default(),
+                sys::t_vpi_vecval { aval: 1, bval: 1 },
+            ],
+            &format!("x{}", "0".repeat(64)),
+        );
+
+        assert_eq!(
+            signal.get_bigint(),
+            Err(ValueError::FourState(format!("x{}", "0".repeat(64))))
+        );
+    }
+
+    #[test]
     fn vector_write_truncates_and_zero_extends_to_signal_width() {
+        let narrow = make_signal(8, &[sys::t_vpi_vecval::default()], "00000000");
+        narrow.set_u64_now(0xffff_ffff_ffff_ffa5);
+        let words = rustdv_vpi_stubs::last_put_vector();
+        assert_eq!(words.len(), 1);
+        assert_eq!(words[0].aval, 0xa5);
+        assert_eq!(words[0].bval, 0);
+
         let signal = make_signal(37, &[sys::t_vpi_vecval::default(); 2], &"0".repeat(37));
         signal.set_u64_now(0xffff_fff5_89ab_cdef);
         let words = rustdv_vpi_stubs::last_put_vector();
@@ -898,5 +1199,98 @@ mod handle_tests {
         assert_eq!(words[0].aval, 0x89ab_cdef);
         assert_eq!(words[1].aval, 0x0123_4567);
         assert_eq!(words[2].aval, 0);
+    }
+
+    #[test]
+    fn typed_integer_setters_write_vpi_words() {
+        let signal = make_signal(1, &[sys::t_vpi_vecval::default()], "0");
+        signal.set_bool_now(true);
+        assert_eq!(rustdv_vpi_stubs::last_put_vector()[0].aval, 1);
+
+        let signal = make_signal(8, &[sys::t_vpi_vecval::default()], "00000000");
+        signal.set_u8(0xa5, sys::vpiNoDelay);
+        assert_eq!(rustdv_vpi_stubs::last_put_vector()[0].aval, 0xa5);
+
+        let signal = make_signal(16, &[sys::t_vpi_vecval::default()], &"0".repeat(16));
+        signal.set_u16_now(0xa5b6);
+        assert_eq!(rustdv_vpi_stubs::last_put_vector()[0].aval, 0xa5b6);
+
+        let signal = make_signal(32, &[sys::t_vpi_vecval::default()], &"0".repeat(32));
+        signal.set_u32_now(0xa5b6_c7d8);
+        assert_eq!(rustdv_vpi_stubs::last_put_vector()[0].aval, 0xa5b6_c7d8);
+
+        let signal = make_signal(128, &[sys::t_vpi_vecval::default(); 4], &"0".repeat(128));
+        signal.set_u128_now(0x0123_4567_89ab_cdef_fedc_ba98_7654_3210);
+        let words = rustdv_vpi_stubs::last_put_vector();
+        assert_eq!(
+            words.iter().map(|word| word.aval).collect::<Vec<_>>(),
+            [0x7654_3210, 0xfedc_ba98, 0x89ab_cdef, 0x0123_4567]
+        );
+        assert!(words.iter().all(|word| word.bval == 0));
+    }
+
+    #[test]
+    fn bigint_setter_writes_and_zero_extends_vpi_words() {
+        let signal = make_signal(192, &[sys::t_vpi_vecval::default(); 6], &"0".repeat(192));
+        let value = BigUint::from_slice(&[
+            0x7654_3210,
+            0xfedc_ba98,
+            0x89ab_cdef,
+            0x0123_4567,
+            0xa5a5_5a5a,
+        ]);
+
+        signal.set_bigint_now(&value);
+
+        let words = rustdv_vpi_stubs::last_put_vector();
+        assert_eq!(
+            words.iter().map(|word| word.aval).collect::<Vec<_>>(),
+            [
+                0x7654_3210,
+                0xfedc_ba98,
+                0x89ab_cdef,
+                0x0123_4567,
+                0xa5a5_5a5a,
+                0,
+            ]
+        );
+        assert!(words.iter().all(|word| word.bval == 0));
+    }
+
+    #[test]
+    fn vector_word_mask_clears_unused_aval_and_bval_bits() {
+        let signal = make_signal(37, &[sys::t_vpi_vecval::default(); 2], &"0".repeat(37));
+        let mut words = [
+            sys::t_vpi_vecval {
+                aval: u32::MAX,
+                bval: u32::MAX,
+            },
+            sys::t_vpi_vecval {
+                aval: u32::MAX,
+                bval: u32::MAX,
+            },
+        ];
+
+        signal.mask_vector_words(&mut words);
+
+        assert_eq!(words[0].aval, u32::MAX);
+        assert_eq!(words[0].bval, u32::MAX);
+        assert_eq!(words[1].aval, 0x1f);
+        assert_eq!(words[1].bval, 0x1f);
+    }
+
+    #[test]
+    fn logic_array_write_uses_vpi_vector_words() {
+        let signal = make_signal(
+            4,
+            &[sys::t_vpi_vecval::default()],
+            "binary-string path must not be used",
+        );
+        signal.set_logic_now(&LogicArray::from_binstr("01xz"));
+
+        let words = rustdv_vpi_stubs::last_put_vector();
+        assert_eq!(words.len(), 1);
+        assert_eq!(words[0].aval, 0b0110);
+        assert_eq!(words[0].bval, 0b0011);
     }
 }

--- a/rustdv/rustdv-gpi/src/util.rs
+++ b/rustdv/rustdv-gpi/src/util.rs
@@ -1,0 +1,80 @@
+use rustdv_gpi_sys as sys;
+
+/// Convert a two-state value to a fixed-size array of VPI vector words.
+pub trait ToVpiWords<const N: usize> {
+    fn to_vpi_words(self) -> [sys::t_vpi_vecval; N];
+}
+
+impl ToVpiWords<1> for bool {
+    fn to_vpi_words(self) -> [sys::t_vpi_vecval; 1] {
+        [sys::t_vpi_vecval {
+            aval: self as u32,
+            bval: 0,
+        }]
+    }
+}
+
+impl ToVpiWords<1> for u8 {
+    fn to_vpi_words(self) -> [sys::t_vpi_vecval; 1] {
+        [sys::t_vpi_vecval {
+            aval: self as u32,
+            bval: 0,
+        }]
+    }
+}
+
+impl ToVpiWords<1> for u16 {
+    fn to_vpi_words(self) -> [sys::t_vpi_vecval; 1] {
+        [sys::t_vpi_vecval {
+            aval: self as u32,
+            bval: 0,
+        }]
+    }
+}
+
+impl ToVpiWords<1> for u32 {
+    fn to_vpi_words(self) -> [sys::t_vpi_vecval; 1] {
+        [sys::t_vpi_vecval {
+            aval: self,
+            bval: 0,
+        }]
+    }
+}
+
+impl ToVpiWords<2> for u64 {
+    fn to_vpi_words(self) -> [sys::t_vpi_vecval; 2] {
+        [
+            sys::t_vpi_vecval {
+                aval: self as u32,
+                bval: 0,
+            },
+            sys::t_vpi_vecval {
+                aval: (self >> 32) as u32,
+                bval: 0,
+            },
+        ]
+    }
+}
+
+impl ToVpiWords<4> for u128 {
+    fn to_vpi_words(self) -> [sys::t_vpi_vecval; 4] {
+        [
+            sys::t_vpi_vecval {
+                aval: self as u32,
+                bval: 0,
+            },
+            sys::t_vpi_vecval {
+                aval: (self >> 32) as u32,
+                bval: 0,
+            },
+            sys::t_vpi_vecval {
+                aval: (self >> 64) as u32,
+                bval: 0,
+            },
+            sys::t_vpi_vecval {
+                aval: (self >> 96) as u32,
+                bval: 0,
+            },
+        ]
+    }
+}

--- a/rustdv/rustdv-gpi/src/value.rs
+++ b/rustdv/rustdv-gpi/src/value.rs
@@ -4,6 +4,8 @@
 
 use std::fmt;
 
+use num_bigint::BigUint;
+
 use crate::ValueError;
 
 /// One 4-state bit.
@@ -49,64 +51,240 @@ impl fmt::Display for Logic {
     }
 }
 
-/// A fixed-width vector of 4-state bits, MSB first (binstr order).
+/// A fixed-width vector of 4-state bits using VPI's `a_val`/`b_val`
+/// representation. Bit pairs encode `00=0`, `10=1`, `11=X`, and `01=Z`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct LogicArray {
-    bits: Vec<Logic>,
+    a_val: BigUint,
+    b_val: BigUint,
+    width: usize,
 }
 
 impl LogicArray {
-    pub fn from_binstr(s: &str) -> LogicArray {
-        LogicArray {
-            bits: s.chars().map(Logic::from_char).collect(),
+    /// Construct from VPI vector words in least-significant-word-first order.
+    /// Each tuple is `(aval, bval)`. `width` preserves the exact signal width
+    /// when the final word uses fewer than 32 bits.
+    pub fn from_vpi_words(words: &[(u32, u32)], width: usize) -> LogicArray {
+        let word_count = width.div_ceil(32);
+        assert_eq!(
+            words.len(),
+            word_count,
+            "{width}-bit LogicArray needs {word_count} VPI word(s), got {}",
+            words.len()
+        );
+
+        let mut a_words: Vec<u32> = words.iter().map(|(aval, _)| *aval).collect();
+        let mut b_words: Vec<u32> = words.iter().map(|(_, bval)| *bval).collect();
+        if !width.is_multiple_of(32) {
+            let mask = (1u32 << (width % 32)) - 1;
+            *a_words.last_mut().expect("partial width has a VPI word") &= mask;
+            *b_words.last_mut().expect("partial width has a VPI word") &= mask;
         }
+
+        LogicArray {
+            a_val: BigUint::from_slice(&a_words),
+            b_val: BigUint::from_slice(&b_words),
+            width,
+        }
+    }
+
+    pub fn from_binstr(s: &str) -> LogicArray {
+        let mut a_val = BigUint::ZERO;
+        let mut b_val = BigUint::ZERO;
+        let mut width = 0;
+        for (bit, c) in s.chars().rev().enumerate() {
+            let bit = bit as u64;
+            match Logic::from_char(c) {
+                Logic::Zero => {}
+                Logic::One => a_val.set_bit(bit, true),
+                Logic::X => {
+                    a_val.set_bit(bit, true);
+                    b_val.set_bit(bit, true);
+                }
+                Logic::Z => b_val.set_bit(bit, true),
+            }
+            width += 1;
+        }
+        LogicArray {
+            a_val,
+            b_val,
+            width,
+        }
+    }
+
+    pub fn from_bool(v: bool, width: usize) -> LogicArray {
+        LogicArray::from_u128(v as u128, width)
+    }
+
+    pub fn from_u8(v: u8, width: usize) -> LogicArray {
+        LogicArray::from_u128(v as u128, width)
+    }
+
+    pub fn from_u16(v: u16, width: usize) -> LogicArray {
+        LogicArray::from_u128(v as u128, width)
+    }
+
+    pub fn from_u32(v: u32, width: usize) -> LogicArray {
+        LogicArray::from_u128(v as u128, width)
     }
 
     pub fn from_u64(v: u64, width: usize) -> LogicArray {
-        let mut bits = Vec::with_capacity(width);
-        for i in (0..width).rev() {
-            bits.push(Logic::from((v >> i) & 1 == 1));
+        LogicArray::from_u128(v as u128, width)
+    }
+
+    pub fn from_u128(v: u128, width: usize) -> LogicArray {
+        let mut a_val = BigUint::ZERO;
+        for bit in 0..width.min(u128::BITS as usize) {
+            if v & (1u128 << bit) != 0 {
+                a_val.set_bit(bit as u64, true);
+            }
         }
-        LogicArray { bits }
+        LogicArray {
+            a_val,
+            b_val: BigUint::ZERO,
+            width,
+        }
+    }
+
+    pub fn from_bigint(v: &BigUint, width: usize) -> LogicArray {
+        let mask = (BigUint::from(1u8) << width) - BigUint::from(1u8);
+        LogicArray {
+            a_val: v & mask,
+            b_val: BigUint::ZERO,
+            width,
+        }
+    }
+
+    /// Return VPI vector words in least-significant-word-first order.
+    /// Each tuple is `(aval, bval)`.
+    pub fn to_vpi_words(&self) -> Vec<(u32, u32)> {
+        let word_count = self.width.div_ceil(32);
+        let mut a_words = self.a_val.iter_u32_digits();
+        let mut b_words = self.b_val.iter_u32_digits();
+        (0..word_count)
+            .map(|_| (a_words.next().unwrap_or(0), b_words.next().unwrap_or(0)))
+            .collect()
     }
 
     pub fn to_binstr(&self) -> String {
-        self.bits.iter().map(|b| b.to_char()).collect()
+        (0..self.width)
+            .rev()
+            .map(|index| {
+                self[index]
+                    .expect("index generated from LogicArray width")
+                    .to_char()
+            })
+            .collect()
     }
 
     pub fn len(&self) -> usize {
-        self.bits.len()
+        self.width
     }
     pub fn is_empty(&self) -> bool {
-        self.bits.is_empty()
+        self.width == 0
     }
 
+    /// Return true if the value is resolvable to a 2-state value (no X/Z bits).
     pub fn is_resolvable(&self) -> bool {
-        self.bits.iter().all(|b| b.is_resolvable())
+        self.b_val == BigUint::ZERO
     }
+}
 
-    /// MSB-first bit access.
-    pub fn bit(&self, i: usize) -> Option<Logic> {
-        self.bits.get(i).copied()
-    }
-
-    pub fn to_u64(&self) -> Result<u64, ValueError> {
-        let mut v: u64 = 0;
-        for b in &self.bits {
-            match b {
-                Logic::Zero => v <<= 1,
-                Logic::One => v = (v << 1) | 1,
-                _ => return Err(ValueError::FourState(self.to_binstr())),
-            }
+impl TryFrom<&LogicArray> for bool {
+    type Error = ValueError;
+    fn try_from(v: &LogicArray) -> Result<bool, ValueError> {
+        if !v.is_resolvable() {
+            return Err(ValueError::FourState(v.to_binstr()));
         }
-        Ok(v)
+        Ok(v.a_val != BigUint::ZERO)
+    }
+}
+
+impl TryFrom<&LogicArray> for u8 {
+    type Error = ValueError;
+    fn try_from(v: &LogicArray) -> Result<u8, ValueError> {
+        if !v.is_resolvable() {
+            return Err(ValueError::FourState(v.to_binstr()));
+        }
+        Ok(v.a_val.iter_u32_digits().next().unwrap_or(0) as u8)
+    }
+}
+
+impl TryFrom<&LogicArray> for u16 {
+    type Error = ValueError;
+    fn try_from(v: &LogicArray) -> Result<u16, ValueError> {
+        if !v.is_resolvable() {
+            return Err(ValueError::FourState(v.to_binstr()));
+        }
+        Ok(v.a_val.iter_u32_digits().next().unwrap_or(0) as u16)
+    }
+}
+
+impl TryFrom<&LogicArray> for u32 {
+    type Error = ValueError;
+    fn try_from(v: &LogicArray) -> Result<u32, ValueError> {
+        if !v.is_resolvable() {
+            return Err(ValueError::FourState(v.to_binstr()));
+        }
+        Ok(v.a_val.iter_u32_digits().next().unwrap_or(0))
     }
 }
 
 impl TryFrom<&LogicArray> for u64 {
     type Error = ValueError;
     fn try_from(v: &LogicArray) -> Result<u64, ValueError> {
-        v.to_u64()
+        if !v.is_resolvable() {
+            return Err(ValueError::FourState(v.to_binstr()));
+        }
+        Ok(v.a_val.iter_u64_digits().next().unwrap_or(0))
+    }
+}
+
+impl TryFrom<&LogicArray> for u128 {
+    type Error = ValueError;
+    fn try_from(v: &LogicArray) -> Result<u128, ValueError> {
+        if !v.is_resolvable() {
+            return Err(ValueError::FourState(v.to_binstr()));
+        }
+        let mut digits = v.a_val.iter_u64_digits();
+        let low = digits.next().unwrap_or(0) as u128;
+        let high = digits.next().unwrap_or(0) as u128;
+        Ok(low | (high << 64))
+    }
+}
+
+impl TryFrom<&LogicArray> for BigUint {
+    type Error = ValueError;
+    fn try_from(v: &LogicArray) -> Result<BigUint, ValueError> {
+        if !v.is_resolvable() {
+            return Err(ValueError::FourState(v.to_binstr()));
+        }
+        Ok(v.a_val.clone())
+    }
+}
+
+/// Access bits least-significant-bit first, returning `None` out of bounds.
+impl std::ops::Index<usize> for LogicArray {
+    type Output = Option<Logic>;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        // Return references to the decoded logic states.
+        static ZERO: Option<Logic> = Some(Logic::Zero);
+        static ONE: Option<Logic> = Some(Logic::One);
+        static X: Option<Logic> = Some(Logic::X);
+        static Z: Option<Logic> = Some(Logic::Z);
+        // Check if the index is out of bounds first
+        if index >= self.width {
+            return &None;
+        }
+        // Return a reference to the appropriate static value based on
+        // a_val and b_val
+        match (self.a_val.bit(index as u64), self.b_val.bit(index as u64)) {
+            (false, false) => &ZERO,
+            (true, false) => &ONE,
+            (true, true) => &X,
+            (false, true) => &Z,
+        }
     }
 }
 
@@ -124,13 +302,130 @@ mod tests {
     fn roundtrip_u64() {
         let v = LogicArray::from_u64(0xA5, 8);
         assert_eq!(v.to_binstr(), "10100101");
-        assert_eq!(v.to_u64().unwrap(), 0xA5);
+        assert_eq!(u64::try_from(&v).unwrap(), 0xA5);
+    }
+
+    #[test]
+    fn constructs_from_two_state_primitive_types() {
+        let v = LogicArray::from_bool(true, 1);
+        assert_eq!(v.to_binstr(), "1");
+
+        let v = LogicArray::from_u8(0xa5, 8);
+        assert_eq!(u8::try_from(&v), Ok(0xa5));
+
+        let v = LogicArray::from_u16(0xa5b6, 16);
+        assert_eq!(u16::try_from(&v), Ok(0xa5b6));
+
+        let v = LogicArray::from_u32(0xa5b6_c7d8, 32);
+        assert_eq!(u32::try_from(&v), Ok(0xa5b6_c7d8));
+
+        let v = LogicArray::from_u64(0x0123_4567_89ab_cdef, 64);
+        assert_eq!(u64::try_from(&v), Ok(0x0123_4567_89ab_cdef));
+
+        let value = 0x0123_4567_89ab_cdef_fedc_ba98_7654_3210;
+        let v = LogicArray::from_u128(value, 128);
+        assert_eq!(u128::try_from(&v), Ok(value));
+
+        let truncated = LogicArray::from_u8(0xa5, 4);
+        assert_eq!(truncated.to_binstr(), "0101");
+    }
+
+    #[test]
+    fn bigint_conversion_preserves_arbitrary_width_values() {
+        let value = BigUint::from_slice(&[
+            0x7654_3210,
+            0xfedc_ba98,
+            0x89ab_cdef,
+            0x0123_4567,
+            0xa5a5_5a5a,
+        ]);
+        let v = LogicArray::from_bigint(&value, 160);
+
+        assert_eq!(v.len(), 160);
+        assert_eq!(BigUint::try_from(&v), Ok(value));
+
+        let truncated = LogicArray::from_bigint(&BigUint::from(0xffu8), 4);
+        assert_eq!(BigUint::try_from(&truncated), Ok(BigUint::from(0x0fu8)));
+    }
+
+    #[test]
+    fn converts_to_two_state_primitive_types() {
+        let zero = LogicArray::from_binstr("0");
+        assert_eq!(bool::try_from(&zero), Ok(false));
+
+        let v = LogicArray::from_vpi_words(
+            &[
+                (0x7654_3210, 0),
+                (0xfedc_ba98, 0),
+                (0x89ab_cdef, 0),
+                (0x0123_4567, 0),
+            ],
+            128,
+        );
+        assert_eq!(bool::try_from(&v), Ok(true));
+        assert_eq!(u8::try_from(&v), Ok(0x10));
+        assert_eq!(u16::try_from(&v), Ok(0x3210));
+        assert_eq!(u32::try_from(&v), Ok(0x7654_3210));
+        assert_eq!(u64::try_from(&v), Ok(0xfedc_ba98_7654_3210));
+        assert_eq!(
+            u128::try_from(&v),
+            Ok(0x0123_4567_89ab_cdef_fedc_ba98_7654_3210)
+        );
     }
 
     #[test]
     fn four_state_rejected() {
         let v = LogicArray::from_binstr("1x0z");
-        assert!(v.to_u64().is_err());
+        assert!(bool::try_from(&v).is_err());
+        assert!(u8::try_from(&v).is_err());
+        assert!(u16::try_from(&v).is_err());
+        assert!(u32::try_from(&v).is_err());
+        assert!(u64::try_from(&v).is_err());
+        assert!(u128::try_from(&v).is_err());
+        assert!(BigUint::try_from(&v).is_err());
         assert!(!v.is_resolvable());
+    }
+
+    #[test]
+    fn vpi_encoding_and_lsb_first_bit_access() {
+        let v = LogicArray::from_binstr("01xz");
+
+        assert_eq!(v.a_val, BigUint::from(0b0110u8));
+        assert_eq!(v.b_val, BigUint::from(0b0011u8));
+        assert_eq!(v[0], Some(Logic::Z));
+        assert_eq!(v[1], Some(Logic::X));
+        assert_eq!(v[2], Some(Logic::One));
+        assert_eq!(v[3], Some(Logic::Zero));
+        assert_eq!(v[4], None);
+        assert_eq!(v.to_binstr(), "01xz");
+    }
+
+    #[test]
+    fn constructs_from_vpi_words_and_masks_unused_bits() {
+        let states = LogicArray::from_vpi_words(&[(0b0110, 0b0011)], 4);
+        assert_eq!(states.to_binstr(), "01xz");
+        assert_eq!(states.to_vpi_words(), vec![(0b0110, 0b0011)]);
+
+        let partial = LogicArray::from_vpi_words(&[(0xffff_fff5, 0xffff_fff8)], 3);
+        assert_eq!(partial.to_binstr(), "101");
+        assert!(partial.is_resolvable());
+        assert_eq!(partial.to_vpi_words(), vec![(0b101, 0)]);
+    }
+
+    #[test]
+    fn width_is_preserved_independently_of_biguint_magnitude() {
+        let zeros = LogicArray::from_binstr("00000");
+        assert_eq!(zeros.len(), 5);
+        assert_eq!(zeros.to_binstr(), "00000");
+
+        let wide = LogicArray::from_u64(1, 65);
+        assert_eq!(wide.len(), 65);
+        assert_eq!(wide[0], Some(Logic::One));
+        assert_eq!(wide[64], Some(Logic::Zero));
+        assert_eq!(u64::try_from(&wide), Ok(1));
+
+        let empty = LogicArray::from_binstr("");
+        assert!(empty.is_empty());
+        assert_eq!(empty.to_binstr(), "");
     }
 }

--- a/rustdv/rustdv-sim/src/handle.rs
+++ b/rustdv/rustdv-sim/src/handle.rs
@@ -4,7 +4,7 @@
 //! `set_now()` is the immediate variant.
 
 use rustdv_gpi as gpi;
-pub use rustdv_gpi::{HandleError, Logic, LogicArray, ValueError};
+pub use rustdv_gpi::{BigUint, HandleError, Logic, LogicArray, ValueError};
 
 use crate::phase;
 use crate::triggers::{Edge, EdgeKind};
@@ -115,33 +115,121 @@ impl LogicHandle {
         self.raw.size()
     }
 
-    // ---- read ----
-    pub fn get(&self) -> LogicArray {
-        self.raw.get()
+    // ----------------- Read: current value (mapping row 19) -----------------
+
+    /// Current boolean value, or `Err` if VPI does not supply it.
+    pub fn get_bool(&self) -> Result<bool, ValueError> {
+        self.raw.get_bool()
     }
-    pub fn get_binstr(&self) -> String {
-        self.raw.get_binstr()
+
+    /// Current unsigned 8-bit value, or `Err` if VPI does not supply it.
+    pub fn get_u8(&self) -> Result<u8, ValueError> {
+        self.raw.get_u8()
     }
+    /// Current unsigned 16-bit value, or `Err` if VPI does not supply it.
+    pub fn get_u16(&self) -> Result<u16, ValueError> {
+        self.raw.get_u16()
+    }
+
+    /// Current unsigned 32-bit value, or `Err` if VPI does not supply it.
+    pub fn get_u32(&self) -> Result<u32, ValueError> {
+        self.raw.get_u32()
+    }
+
+    /// Current unsigned 64-bit value, or `Err` if VPI does not supply it.
     pub fn get_u64(&self) -> Result<u64, ValueError> {
         self.raw.get_u64()
     }
-    /// Convenience for 1-bit signals: true iff the value is 1.
+
+    /// Current unsigned 128-bit value, or `Err` if VPI does not supply it.
+    pub fn get_u128(&self) -> Result<u128, ValueError> {
+        self.raw.get_u128()
+    }
+
+    /// Current arbitrary-width unsigned value, or `Err` if VPI does not supply it.
+    pub fn get_bigint(&self) -> Result<BigUint, ValueError> {
+        self.raw.get_bigint()
+    }
+
+    /// Current four-state value, or `Err` if VPI does not supply it.
+    pub fn get_logic(&self) -> Result<LogicArray, ValueError> {
+        self.raw.get_logic()
+    }
+
+    /// Current four-state value formatted as an MSB-first binary string.
+    pub fn get_binstr(&self) -> Result<String, ValueError> {
+        Ok(self.raw.get_logic()?.to_binstr())
+    }
+
+    /// Convenience for 1-bit signals: true iff the value is 1b1.
     pub fn is_high(&self) -> bool {
-        self.size() == 1 && self.raw.get_u64() == Ok(1)
+        self.raw.get_bool() == Ok(true)
     }
+
+    /// Convenience for 1-bit signals: true iff the value is 1b0.
     pub fn is_low(&self) -> bool {
-        self.size() == 1 && self.raw.get_u64() == Ok(0)
+        self.raw.get_bool() == Ok(false)
     }
 
-    // ---- write: scheduled (applied at next ReadWrite phase, row 22) ----
+    // ------ Write: scheduled (applied at next ReadWrite phase, row 22) ------
+
+    /// Set the boolean value to be applied at the next ReadWrite phase. The
+    /// write is buffered and the last write wins, preserving order of distinct
+    /// signals.
+    pub fn set_bool(&self, v: bool) {
+        phase::schedule(self.raw, phase::WriteVal::Bool(v));
+    }
+
+    /// Set the unsigned 8-bit value to be applied at the next ReadWrite phase.
+    /// The write is buffered and the last write wins, preserving order of
+    /// distinct signals.
+    pub fn set_u8(&self, v: u8) {
+        phase::schedule(self.raw, phase::WriteVal::U8(v));
+    }
+
+    /// Set the unsigned 16-bit value to be applied at the next ReadWrite phase.
+    /// The write is buffered and the last write wins, preserving order of
+    /// distinct signals.
+    pub fn set_u16(&self, v: u16) {
+        phase::schedule(self.raw, phase::WriteVal::U16(v));
+    }
+
+    /// Set the unsigned 32-bit value to be applied at the next ReadWrite phase.
+    /// The write is buffered and the last write wins, preserving order of
+    /// distinct signals.
+    pub fn set_u32(&self, v: u32) {
+        phase::schedule(self.raw, phase::WriteVal::U32(v));
+    }
+
+    /// Set the unsigned 64-bit value to be applied at the next ReadWrite phase.
+    /// The write is buffered and the last write wins, preserving order of
+    /// distinct signals.
     pub fn set_u64(&self, v: u64) {
-        phase::schedule_write_u64(self.raw, v);
-    }
-    pub fn set(&self, v: &LogicArray) {
-        phase::schedule_write_arr(self.raw, v.clone());
+        phase::schedule(self.raw, phase::WriteVal::U64(v));
     }
 
-    // ---- write: immediate (setimmediatevalue analog) ----
+    /// Set the unsigned 128-bit value to be applied at the next ReadWrite
+    /// phase. The write is buffered and the last write wins, preserving order
+    /// of distinct signals.
+    pub fn set_u128(&self, v: u128) {
+        phase::schedule(self.raw, phase::WriteVal::U128(v));
+    }
+
+    /// Set the arbitrary-width unsigned value to be applied at the next
+    /// ReadWrite phase. The write is buffered and the last write wins,
+    /// preserving order of distinct signals.
+    pub fn set_bigint(&self, v: &BigUint) {
+        phase::schedule(self.raw, phase::WriteVal::BigInt(v.clone()));
+    }
+
+    /// Set the four-state value to be applied at the next ReadWrite phase. The
+    /// write is buffered and the last write wins, preserving order of distinct
+    /// signals.
+    pub fn set_logic(&self, v: &LogicArray) {
+        phase::schedule(self.raw, phase::WriteVal::Logic(v.clone()));
+    }
+
+    // -------------- write: immediate (setimmediatevalue analog) --------------
     //
     // Immediate skips the write *scheduler*, not the phase *rule* (D108). The
     // rule is the simulator's: writing during ReadOnly is illegal however the
@@ -151,13 +239,63 @@ impl LogicHandle {
     // callback" — after which the run continued on values that were never
     // applied. That is the worst kind of wrong: it looks like a warning and it
     // silently changes results.
+
+    /// Set the boolean value immediately, skipping the write scheduler. The
+    /// write is applied at once, but the ReadOnly rule is still enforced.
+    pub fn set_bool_now(&self, v: bool) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_bool_now(v);
+    }
+
+    /// Set the unsigned 8-bit value immediately, skipping the write scheduler.
+    /// The write is applied at once, but the ReadOnly rule is still enforced.
+    pub fn set_u8_now(&self, v: u8) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_u8_now(v);
+    }
+
+    /// Set the unsigned 16-bit value immediately, skipping the write scheduler.
+    /// The write is applied at once, but the ReadOnly rule is still enforced.
+    pub fn set_u16_now(&self, v: u16) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_u16_now(v);
+    }
+
+    /// Set the unsigned 32-bit value immediately, skipping the write scheduler.
+    /// The write is applied at once, but the ReadOnly rule is still enforced.
+    pub fn set_u32_now(&self, v: u32) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_u32_now(v);
+    }
+
+    /// Set the unsigned 64-bit value immediately, skipping the write scheduler.
+    /// The write is applied at once, but the ReadOnly rule is still enforced.
     pub fn set_u64_now(&self, v: u64) {
         phase::deny_write_in_read_only(self.raw);
         self.raw.set_u64_now(v);
     }
-    pub fn set_now(&self, v: &LogicArray) {
+
+    /// Set the unsigned 128-bit value immediately, skipping the write
+    /// scheduler. The write is applied at once, but the ReadOnly rule is still
+    /// enforced.
+    pub fn set_u128_now(&self, v: u128) {
         phase::deny_write_in_read_only(self.raw);
-        self.raw.set_now(v);
+        self.raw.set_u128_now(v);
+    }
+
+    /// Set the arbitrary-width unsigned value immediately, skipping the write
+    /// scheduler. The write is applied at once, but the ReadOnly rule is still
+    /// enforced.
+    pub fn set_bigint_now(&self, v: &BigUint) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_bigint_now(v);
+    }
+
+    /// Set the four-state value immediately, skipping the write scheduler. The
+    /// write is applied at once, but the ReadOnly rule is still enforced.
+    pub fn set_logic_now(&self, v: &LogicArray) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_logic_now(v);
     }
 
     // ---- edges (methods on typed handles, mapping row 14) ----

--- a/rustdv/rustdv-sim/src/phase.rs
+++ b/rustdv/rustdv-sim/src/phase.rs
@@ -15,7 +15,7 @@ use std::rc::Rc;
 use std::task::{Context, Poll, Waker};
 
 use rustdv_gpi as gpi;
-use rustdv_gpi::LogicArray;
+use rustdv_gpi::{BigUint, LogicArray};
 
 use crate::executor;
 
@@ -26,9 +26,15 @@ pub enum SimPhase {
     ReadOnly,
 }
 
-enum WriteVal {
+pub(crate) enum WriteVal {
+    Bool(bool),
+    U8(u8),
+    U16(u16),
+    U32(u32),
     U64(u64),
-    Arr(LogicArray),
+    U128(u128),
+    BigInt(BigUint),
+    Logic(LogicArray),
 }
 
 struct Hub {
@@ -109,8 +115,14 @@ pub async fn leave_read_only() {
 
 fn apply_write(h: gpi::LogicHandle, v: &WriteVal) {
     match v {
+        WriteVal::Bool(x) => h.set_bool_now(*x),
+        WriteVal::U8(x) => h.set_u8_now(*x),
+        WriteVal::U16(x) => h.set_u16_now(*x),
+        WriteVal::U32(x) => h.set_u32_now(*x),
         WriteVal::U64(x) => h.set_u64_now(*x),
-        WriteVal::Arr(a) => h.set_now(a),
+        WriteVal::U128(x) => h.set_u128_now(*x),
+        WriteVal::BigInt(x) => h.set_bigint_now(x),
+        WriteVal::Logic(x) => h.set_logic_now(x),
     }
 }
 
@@ -125,7 +137,7 @@ pub(crate) fn deny_write_in_read_only(h: gpi::LogicHandle) {
     }
 }
 
-fn schedule(h: gpi::LogicHandle, v: WriteVal) {
+pub(crate) fn schedule(h: gpi::LogicHandle, v: WriteVal) {
     let hub = hub();
     match hub.phase.get() {
         SimPhase::ReadOnly => deny_write_in_read_only(h),
@@ -142,14 +154,6 @@ fn schedule(h: gpi::LogicHandle, v: WriteVal) {
             prime_rw(&hub);
         }
     }
-}
-
-pub(crate) fn schedule_write_u64(h: gpi::LogicHandle, v: u64) {
-    schedule(h, WriteVal::U64(v));
-}
-
-pub(crate) fn schedule_write_arr(h: gpi::LogicHandle, v: LogicArray) {
-    schedule(h, WriteVal::Arr(v));
 }
 
 // ---------------------------------------------------------------------------

--- a/rustdv/rustdv-sim/src/rustdv_sim.rs
+++ b/rustdv/rustdv-sim/src/rustdv_sim.rs
@@ -40,7 +40,7 @@ pub use sync::{Event, Lock, LockGuard};
 pub use time::{SimDuration, sim_time_ns, sim_time_steps};
 pub use triggers::{NullTrigger, Timer};
 
-pub use rustdv_gpi::{HandleError, Logic, LogicArray, ValueError};
+pub use rustdv_gpi::{BigUint, HandleError, Logic, LogicArray, ValueError};
 
 /// Initialize the sim context: install a fresh executor and phase hub on
 /// this thread. Called once by the runner at start-of-simulation.

--- a/rustdv/rustdv-vpi-stubs/src/rustdv_vpi_stubs.rs
+++ b/rustdv/rustdv-vpi-stubs/src/rustdv_vpi_stubs.rs
@@ -40,6 +40,7 @@ struct StubCallback {
 struct StubSignal {
     width: i32,
     words: Vec<t_vpi_vecval>,
+    vector_value_available: bool,
     binstr: CString,
     last_put: Vec<t_vpi_vecval>,
 }
@@ -49,6 +50,7 @@ impl Default for StubSignal {
         Self {
             width: 37,
             words: vec![t_vpi_vecval::default(); 2],
+            vector_value_available: true,
             binstr: CString::new("0".repeat(37)).expect("static binary string contains no NUL"),
             last_put: Vec::new(),
         }
@@ -74,10 +76,16 @@ pub fn configure_signal(width: i32, words: &[t_vpi_vecval], binstr: &str) {
         *signal.borrow_mut() = StubSignal {
             width,
             words: words[..word_count].to_vec(),
+            vector_value_available: true,
             binstr: CString::new(binstr).expect("stub binary string contains NUL"),
             last_put: Vec::new(),
         };
     });
+}
+
+/// Make the next configured signal return no `vpiVectorVal` storage.
+pub fn make_vector_value_unavailable() {
+    SIGNAL.with(|signal| signal.borrow_mut().vector_value_available = false);
 }
 
 /// Return the vector words most recently written by `vpi_put_value`.
@@ -204,7 +212,11 @@ pub unsafe extern "C" fn vpi_get_value(_handle: vpiHandle, value: *mut t_vpi_val
         let value = unsafe { &mut *value };
         match value.format {
             format if format == vpiVectorVal => {
-                value.value.vector = signal.words.as_ptr().cast_mut();
+                value.value.vector = if signal.vector_value_available {
+                    signal.words.as_ptr().cast_mut()
+                } else {
+                    std::ptr::null_mut()
+                };
             }
             format if format == vpiBinStrVal => {
                 value.value.str_ = signal.binstr.as_ptr().cast_mut();

--- a/rustdv/src/rustdv.rs
+++ b/rustdv/src/rustdv.rs
@@ -44,10 +44,11 @@ pub use rustdv_runner::{TEST_REGISTRATIONS, TestRegistration};
 pub use rustdv_sim::handle::top_module;
 pub use rustdv_sim::log;
 pub use rustdv_sim::{
-    AnyHandle, Clock, Either, Event, Executor, HandleError, HierarchyHandle, Lock, LockGuard,
-    Logic, LogicArray, LogicHandle, NullTrigger, Queue, Rng, RustdvPath, SimDuration, TaskError,
-    TaskHandle, TaskState, TimeoutError, Timer, ValueError, first2, join2, next_time_step,
-    read_only, read_write, sim_time_ns, sim_time_steps, spawn, spawn_named, with_timeout,
+    AnyHandle, BigUint, Clock, Either, Event, Executor, HandleError, HierarchyHandle, Lock,
+    LockGuard, Logic, LogicArray, LogicHandle, NullTrigger, Queue, Rng, RustdvPath, SimDuration,
+    TaskError, TaskHandle, TaskState, TimeoutError, Timer, ValueError, first2, join2,
+    next_time_step, read_only, read_write, sim_time_ns, sim_time_steps, spawn, spawn_named,
+    with_timeout,
 };
 
 pub use rustdv_methodology::{
@@ -79,16 +80,16 @@ pub use rustdv_methodology::Component;
 pub mod prelude {
     pub use crate::log;
     pub use crate::{
-        Active, AnalysisBus, CheckSink, Clock, Component, ComponentNode, ConfigDb, Either, Event,
-        Factory, GetPort, HandleError, HierarchyHandle, Lock, Logic, LogicArray, LogicHandle,
-        NullTrigger, ObjectionGuard, PeekPort, PortName, PortOwner, PublishPort, PutPort, Queue,
-        Receiver, Rng, RustdvComp, RustdvCtx, RustdvSeq, RustdvShared, Sender, SeqCtx, SeqError,
-        SeqItem, SeqItemExport, SeqItemPort, Sequence, Sequencer, SimDuration, SubscribePort,
-        Subscriber, TaskHandle, TestError, Timer, TlmFifo, TxnId, build_all, channel, check_all,
-        connect_all, create_seq, end_of_elaboration_all, extract_all, final_all, first2, join2,
-        next_time_step, print_hierarchy, read_only, read_write, report_all, run_component_test,
-        run_extract_check_report, set_seq_override, sim_time_ns, spawn, spawn_named, start_all,
-        start_of_simulation_all, with_timeout,
+        Active, AnalysisBus, BigUint, CheckSink, Clock, Component, ComponentNode, ConfigDb, Either,
+        Event, Factory, GetPort, HandleError, HierarchyHandle, Lock, Logic, LogicArray,
+        LogicHandle, NullTrigger, ObjectionGuard, PeekPort, PortName, PortOwner, PublishPort,
+        PutPort, Queue, Receiver, Rng, RustdvComp, RustdvCtx, RustdvSeq, RustdvShared, Sender,
+        SeqCtx, SeqError, SeqItem, SeqItemExport, SeqItemPort, Sequence, Sequencer, SimDuration,
+        SubscribePort, Subscriber, TaskHandle, TestError, Timer, TlmFifo, TxnId, build_all,
+        channel, check_all, connect_all, create_seq, end_of_elaboration_all, extract_all,
+        final_all, first2, join2, next_time_step, print_hierarchy, read_only, read_write,
+        report_all, run_component_test, run_extract_check_report, set_seq_override, sim_time_ns,
+        spawn, spawn_named, start_all, start_of_simulation_all, with_timeout,
     };
 }
 

--- a/rustdv/tinyalu_tb/src/alu_bfm.rs
+++ b/rustdv/tinyalu_tb/src/alu_bfm.rs
@@ -118,8 +118,12 @@ impl TinyAluBfm {
                 async move {
                     loop {
                         clk.falling_edge().await;
-                        let st = start.get_binstr();
-                        let dn = done.get_binstr();
+                        let st = start
+                            .get_binstr()
+                            .expect("start signal did not return a VPI vector value");
+                        let dn = done
+                            .get_binstr()
+                            .expect("done signal did not return a VPI vector value");
                         if st == "0" && dn == "0" {
                             if let Some(cmd) = q.try_get() {
                                 a.set_u64(cmd.a as u64);


### PR DESCRIPTION
Add typed signal reads and writes for bool, unsigned integers through u128, and arbitrary-width BigUint values. Carry these values through VPI conversion and scheduled writes, with explicit errors for unavailable or unresolvable reads.

Expose get_logic/set_logic for four-state values and make get_binstr return a Result. Replace LogicArray::bit(index) with array[index], preserving Option<Logic> and None for out-of-bounds access. Update callers and add unit coverage plus simulator round-trip tests through 160 bits.

Validation: workspace tests and custom/book-listings pass on this branch.
