### PR TITLE
Fix Clippy lints across the workspace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,78 @@ on:
 # the pin has exactly one home and CI cannot drift from a developer's machine.
 
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read the pinned toolchain
+        id: pin
+        run: |
+          channel=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' rust-toolchain.toml)
+          if [ -z "$channel" ]; then
+            echo "::error::could not read [toolchain] channel from rust-toolchain.toml"
+            exit 1
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "pinned toolchain: $channel"
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.pin.outputs.channel }}
+          components: rustfmt
+
+      - name: Confirm the pin took effect
+        run: |
+          want='${{ steps.pin.outputs.channel }}'
+          got=$(rustc --version | awk '{print $2}')
+          echo "rust-toolchain.toml wants $want; rustc reports $got"
+          if [ "$got" != "$want" ]; then
+            echo "::error::CI is running rustc $got but the repository pins $want."
+            echo "::error::Compile-fail error codes and book-sync listings are compared exactly, so they will drift."
+            exit 1
+          fi
+
+      - name: Check Rust formatting
+        run: cargo fmt --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Read the pinned toolchain
+        id: pin
+        run: |
+          channel=$(sed -n 's/^[[:space:]]*channel[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' rust-toolchain.toml)
+          if [ -z "$channel" ]; then
+            echo "::error::could not read [toolchain] channel from rust-toolchain.toml"
+            exit 1
+          fi
+          echo "channel=$channel" >> "$GITHUB_OUTPUT"
+          echo "pinned toolchain: $channel"
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.pin.outputs.channel }}
+          components: clippy
+
+      - name: Confirm the pin took effect
+        run: |
+          want='${{ steps.pin.outputs.channel }}'
+          got=$(rustc --version | awk '{print $2}')
+          echo "rust-toolchain.toml wants $want; rustc reports $got"
+          if [ "$got" != "$want" ]; then
+            echo "::error::CI is running rustc $got but the repository pins $want."
+            echo "::error::Compile-fail error codes and book-sync listings are compared exactly, so they will drift."
+            exit 1
+          fi
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run Clippy
+        run: cargo clippy --workspace --all-targets
+
   # Book-sync + all figure examples (build, run vs goldens, compile-fail,
   # unit tests). Simulator tests auto-skip here (no iverilog installed).
   regress:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,8 @@ repository at ../rustdv-reference, so the repo carries only its own product.
 - The pre-push hook runs the full regression; keep it green. Verify claims
   by running things — transcripts in the book/README files are real output
   and must stay in sync with reruns.
-- After editing Rust code, run `cargo fmt` from the repository root before
+- After editing Rust code, run `cargo fmt` and
+  `cargo clippy --workspace --all-targets` from the repository root before
   handing off the change.
 
 ### Leave no documentation debt — the rule that costs the most when ignored

--- a/rustdv/rustdv-gpi/src/rustdv_gpi.rs
+++ b/rustdv/rustdv-gpi/src/rustdv_gpi.rs
@@ -650,8 +650,10 @@ pub fn finish() {
 // Panic sink (invariant 4)
 // ===========================================================================
 
+type PanicSink = RefCell<Option<Box<dyn Fn(String)>>>;
+
 thread_local! {
-    static PANIC_SINK: RefCell<Option<Box<dyn Fn(String)>>> = const { RefCell::new(None) };
+    static PANIC_SINK: PanicSink = const { RefCell::new(None) };
 }
 
 /// Install the handler invoked when a callback closure panics (the runner
@@ -758,19 +760,19 @@ extern "C" fn trampoline(cb: *mut sys::t_cb_data) -> i32 {
                     sys::vpi_remove_cb(shared.vpi_h.get());
                     // Reclaim the C-side reference before running user code.
                     drop(Rc::from_raw(ud));
-                    if let Some(f) = f {
-                        if let Err(p) = catch_unwind(AssertUnwindSafe(f)) {
-                            report_panic(p);
-                        }
+                    if let Some(f) = f
+                        && let Err(p) = catch_unwind(AssertUnwindSafe(f))
+                    {
+                        report_panic(p);
                     }
                 }
             }
             CbKind::Recurring => {
                 let mut guard = shared.repeat.borrow_mut();
-                if let Some(f) = guard.as_mut() {
-                    if let Err(p) = catch_unwind(AssertUnwindSafe(|| f())) {
-                        report_panic(p);
-                    }
+                if let Some(f) = guard.as_mut()
+                    && let Err(p) = catch_unwind(AssertUnwindSafe(f))
+                {
+                    report_panic(p);
                 }
             }
         }

--- a/rustdv/rustdv-methodology/src/component.rs
+++ b/rustdv/rustdv-methodology/src/component.rs
@@ -33,6 +33,8 @@ use rustdv_sim::rng::Rng;
 use crate::error::TestError;
 use crate::objection::{ObjectionGuard, ObjectionRegistry};
 
+type RunFuture<'a> = Pin<Box<dyn Future<Output = Result<(), TestError>> + 'a>>;
+
 /// Agent activity (pyuvm's ConfigDB `is_active` int becomes an enum —
 /// mapping row 42; illegal values are unrepresentable).
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -259,8 +261,8 @@ impl RustdvCtx {
 /// phase by hand.
 pub trait Component {
     /// 1. `build` — top-down. Where a component constructs its children
-    /// (D6); the gap between "a component exists" and "its children exist"
-    /// that all late binding lives in.
+    ///    (D6); the gap between "a component exists" and "its children exist"
+    ///    that all late binding lives in.
     fn build(&mut self, ctx: &mut RustdvCtx) {
         let _ = ctx;
     }
@@ -277,7 +279,7 @@ pub trait Component {
         let _ = ctx;
     }
     /// 5. `run` — bottom-up, async, objection-gated. The test body; `Err`
-    /// fails the test.
+    ///    fails the test.
     ///
     /// `async fn` in a trait costs dyn-compatibility, which is why the sync
     /// phases are mirrored onto [`DynPhases`] for traversal (D48).
@@ -652,7 +654,7 @@ pub fn run_all<'a>(
         // below reborrows. Each child's context clone carries its derived path
         // (D9) and is moved into the future that uses it, so no borrows overlap.
         {
-            let children: Vec<Pin<Box<dyn Future<Output = Result<(), TestError>> + '_>>> = node
+            let children: Vec<RunFuture<'_>> = node
                 .children_mut()
                 .into_iter()
                 .map(|(name, child)| {
@@ -660,8 +662,7 @@ pub fn run_all<'a>(
                     Box::pin(async move {
                         let mut cctx = cctx;
                         run_all(child, &mut cctx).await
-                    })
-                        as Pin<Box<dyn Future<Output = Result<(), TestError>> + '_>>
+                    }) as RunFuture<'_>
                 })
                 .collect();
 
@@ -682,8 +683,7 @@ pub fn run_all<'a>(
         }
 
         let outcome = {
-            let mut futs: Vec<Pin<Box<dyn Future<Output = Result<(), TestError>> + '_>>> =
-                Vec::new();
+            let mut futs: Vec<RunFuture<'_>> = Vec::new();
             for (name, child) in taken.iter_mut() {
                 let cctx = ctx.child(name);
                 futs.push(Box::pin(async move {

--- a/rustdv/rustdv-methodology/src/config.rs
+++ b/rustdv/rustdv-methodology/src/config.rs
@@ -143,7 +143,7 @@ impl Clone for Entry {
 type Store = BTreeMap<String, BTreeMap<String, BTreeMap<i32, Entry>>>;
 
 thread_local! {
-    static STORE: RefCell<Store> = RefCell::new(Store::new());
+    static STORE: RefCell<Store> = const {RefCell::new(Store::new())};
     static TRACING: Cell<bool> = const { Cell::new(false) };
     /// True while the build phase is walking, so writes take depth-scaled
     /// precedence (D13, tier 2).
@@ -348,11 +348,11 @@ impl ConfigDb {
         STORE.with(|s| {
             for (path, fields) in s.borrow().iter() {
                 for (field, by_prec) in fields.iter() {
-                    if let Some(from) = field.strip_prefix("__factory_override__") {
-                        if let Some((_, e)) = by_prec.iter().next_back() {
-                            let to = e.rendered.trim_start_matches("-> ").to_string();
-                            out.push((path.clone(), from.to_string(), to));
-                        }
+                    if let Some(from) = field.strip_prefix("__factory_override__")
+                        && let Some((_, e)) = by_prec.iter().next_back()
+                    {
+                        let to = e.rendered.trim_start_matches("-> ").to_string();
+                        out.push((path.clone(), from.to_string(), to));
                     }
                 }
             }

--- a/rustdv/rustdv-runner/src/rustdv_runner.rs
+++ b/rustdv/rustdv-runner/src/rustdv_runner.rs
@@ -207,10 +207,10 @@ async fn run_one(reg: &'static TestRegistration, seed: u64) -> Outcome {
     };
 
     // A panic in a child task fails the test even if the body passed.
-    if let Some(bg) = take_background_failure() {
-        if outcome == Outcome::Pass {
-            outcome = fail(bg);
-        }
+    if let Some(bg) = take_background_failure()
+        && outcome == Outcome::Pass
+    {
+        outcome = fail(bg);
     }
 
     if let Some(expected) = reg.expect_error {

--- a/rustdv/rustdv-sim/src/combinators.rs
+++ b/rustdv/rustdv-sim/src/combinators.rs
@@ -77,15 +77,15 @@ impl<A, B> Future for Join2<'_, A, B> {
         // Sound: the inner futures are boxed (their pinning is their own),
         // and ra/rb are plain values we intentionally move on completion.
         let this = unsafe { self.get_unchecked_mut() };
-        if this.ra.is_none() {
-            if let Poll::Ready(v) = this.a.as_mut().poll(cx) {
-                this.ra = Some(v);
-            }
+        if this.ra.is_none()
+            && let Poll::Ready(v) = this.a.as_mut().poll(cx)
+        {
+            this.ra = Some(v);
         }
-        if this.rb.is_none() {
-            if let Poll::Ready(v) = this.b.as_mut().poll(cx) {
-                this.rb = Some(v);
-            }
+        if this.rb.is_none()
+            && let Poll::Ready(v) = this.b.as_mut().poll(cx)
+        {
+            this.rb = Some(v);
         }
         if this.ra.is_some() && this.rb.is_some() {
             Poll::Ready((this.ra.take().unwrap(), this.rb.take().unwrap()))

--- a/rustdv/rustdv-sim/src/executor.rs
+++ b/rustdv/rustdv-sim/src/executor.rs
@@ -97,6 +97,8 @@ struct TaskEntry {
     state_cell: Rc<dyn Fn(TaskState)>,
 }
 
+type FailureSink = Box<dyn Fn(&str)>;
+
 struct ExecInner {
     tasks: RefCell<HashMap<TaskId, TaskEntry>>,
     next_id: Cell<TaskId>,
@@ -108,7 +110,7 @@ struct ExecInner {
     cancel_pending: RefCell<Vec<TaskId>>,
     /// Called whenever any task panics — the runner points this at
     /// "fail the current test" (cocotb: TestManager._task_done_callback).
-    failure_sink: RefCell<Option<Box<dyn Fn(&str)>>>,
+    failure_sink: RefCell<Option<FailureSink>>,
 }
 
 /// The executor (design-doc §4.3). `!Send` — it never leaves the sim thread.
@@ -235,12 +237,12 @@ impl Executor {
         let ids: Vec<TaskId> = self.inner.woken.0.lock().unwrap().drain(..).collect();
         for id in ids {
             let mut tasks = self.inner.tasks.borrow_mut();
-            if let Some(t) = tasks.get_mut(&id) {
-                if t.state == TaskState::Pending {
-                    t.state = TaskState::Scheduled;
-                    (t.state_cell)(TaskState::Scheduled);
-                    self.inner.run_queue.borrow_mut().push_back(id);
-                }
+            if let Some(t) = tasks.get_mut(&id)
+                && t.state == TaskState::Pending
+            {
+                t.state = TaskState::Scheduled;
+                (t.state_cell)(TaskState::Scheduled);
+                self.inner.run_queue.borrow_mut().push_back(id);
             }
         }
     }

--- a/rustdv/rustdv-sim/src/sync.rs
+++ b/rustdv/rustdv-sim/src/sync.rs
@@ -89,21 +89,16 @@ struct LockInner {
 impl LockInner {
     /// Pass ownership to the next waiter, or unlock.
     fn release(&self) {
-        loop {
-            let next = self.waiters.borrow_mut().pop_front();
-            match next {
-                Some(w) => {
-                    w.granted.set(true);
-                    if let Some(waker) = w.waker.borrow_mut().take() {
-                        waker.wake();
-                    }
-                    // Ownership transferred (still locked).
-                    return;
+        match self.waiters.borrow_mut().pop_front() {
+            Some(w) => {
+                w.granted.set(true);
+                if let Some(waker) = w.waker.borrow_mut().take() {
+                    waker.wake();
                 }
-                None => {
-                    self.locked.set(false);
-                    return;
-                }
+                // Ownership transferred (still locked).
+            }
+            None => {
+                self.locked.set(false);
             }
         }
     }

--- a/rustdv/rustdv-sim/src/testing.rs
+++ b/rustdv/rustdv-sim/src/testing.rs
@@ -89,7 +89,7 @@ pub fn assert_pending<F: Future>(fut: F) {
     let mut cx = Context::from_waker(&waker);
 
     for _ in 0..64 {
-        if let Poll::Ready(_) = fut.as_mut().poll(&mut cx) {
+        if fut.as_mut().poll(&mut cx).is_ready() {
             panic!("assert_pending: the future completed, but the test expected it to wait");
         }
         ex.run_until_idle();

--- a/rustdv/rustdv-sim/src/time.rs
+++ b/rustdv/rustdv-sim/src/time.rs
@@ -22,7 +22,7 @@ impl SimDuration {
         } else {
             let div = 10u64.pow((prec - exp) as u32);
             assert!(
-                n % div == 0,
+                n.is_multiple_of(div),
                 "duration {n}e{exp} is below simulator precision 1e{prec}"
             );
             SimDuration { steps: n / div }


### PR DESCRIPTION
Address Clippy findings across the GPI, methodology, runner, and simulator crates. Remove the lock-release loop that always exits on its first iteration and simplify redundant patterns and expressions.

Add separate GitHub Actions jobs for cargo clippy --workspace --all-targets and cargo fmt --all -- --check, using the repository-pinned Rust toolchain. Update repository instructions to require workspace Clippy checks after Rust edits.

Validation: workflow YAML parses; formatting and Clippy checks pass locally on the dependent stack, with existing Clippy warnings.
