### PR TITLE
Fix phase futures completing before simulator callbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,13 +187,33 @@ jobs:
           if [ "$RUNNER_OS" = Linux ]; then
             sudo apt-get update
             sudo apt-get install -y --no-install-recommends \
-              iverilog autoconf flex bison help2man pkg-config libfl-dev \
+              autoconf flex bison gperf help2man pkg-config libfl-dev \
               zlib1g-dev liblz4-dev curl ca-certificates
           else
-            brew install icarus-verilog autoconf flex bison help2man pkg-config lz4
+            brew install autoconf flex bison gperf help2man pkg-config lz4
             echo "$(brew --prefix bison)/bin" >> "$GITHUB_PATH"
             echo "$(brew --prefix flex)/bin" >> "$GITHUB_PATH"
           fi
+
+      - name: Cache Icarus 13.0
+        id: icarus-cache
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/iverilog-13.0
+          key: iverilog-13.0-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Build pinned Icarus
+        if: steps.icarus-cache.outputs.cache-hit != 'true'
+        run: bash ci/install-iverilog.sh "$RUNNER_TEMP/iverilog-13.0"
+
+      - name: Select and verify pinned Icarus
+        run: |
+          echo "$RUNNER_TEMP/iverilog-13.0/bin" >> "$GITHUB_PATH"
+          got="$("$RUNNER_TEMP/iverilog-13.0/bin/iverilog" -V 2>/dev/null | sed -n 's/^Icarus Verilog version \([^ ]*\).*/\1/p')"
+          test "$got" = 13.0 || {
+            echo "::error::expected Icarus 13.0, got $got"
+            exit 1
+          }
 
       - name: Cache Verilator 5.050
         id: verilator-cache

--- a/STATUS.md
+++ b/STATUS.md
@@ -1370,3 +1370,45 @@ reported 221 passes; Icarus entries were skipped because `iverilog` is absent.
 The lone sandbox failure, callback RSS sampling, passed outside the sandbox at
 48 KiB growth over one million callbacks (16 MiB limit). Other available
 Verilator regressions passed.
+
+## Phase waits complete on callback delivery (2026-09-06)
+
+`PhaseFut` now keeps per-registration `TrigShared` completion state. Unrelated
+parent polls remain pending and replace the waker until the simulator services
+that registration. The hub holds weak registrations, releases each callback's
+batch before waking/draining tasks, and retains shared callbacks for surviving
+waiters and scheduled writes. ReadWrite flushing and ReadOnly restrictions are
+unchanged.
+
+Six new simulator tests cover repeated polls, sibling wakeups in `join_all` and
+the component runner, settled combinational data, scheduled-write ordering,
+next-timestep advancement, cancellation and waker release/replacement,
+consecutive callbacks, and illegal ReadOnly operations. All pass on macOS with
+Icarus and Verilator. Restoring the original phase implementation made the
+regression runner reject `custom/sim-triggers`, including the component case.
+
+Workspace unit/doc tests, formatting, Clippy (existing warnings), book listings,
+and the no-stale-versions check pass. The Reptilia dependency update and removal
+of its local workaround are outside this repository change.
+
+Full regression: 252 passed in the sandbox; the sole failure was callback
+stress RSS sampling (`ps` is prohibited there). The same million-cycle stress
+entry passed when rerun outside the sandbox, completing all 253 enabled checks.
+Transcript verification and both simulator scheduler regressions passed.
+
+## CI pins Icarus 13 (2026-09-08)
+
+Icarus 12 delivers next-time callbacks registered from an active callback batch
+at the same timestamp. Reproduced the phase-wait regression failure with that
+release; Icarus 13 passes with the existing phase implementation. CI now builds
+and caches Icarus 13.0 from a checksum-verified release archive on both simulator
+platforms. No runtime compatibility workaround is added.
+
+Missing-output failures now include captured command output so simulator
+assertions are visible in CI logs.
+
+Validation: built Icarus 13.0 from the pinned archive on macOS using the new
+installer, verified its already-installed path, and passed `custom/sim-triggers`
+with the original phase implementation. Workflow YAML and shell syntax checks
+pass. The macOS build supplies the Apple executable-path header through CFLAGS
+because the release driver does not include its declaration.

--- a/ci/install-iverilog.sh
+++ b/ci/install-iverilog.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Build the Icarus release used by the simulator regression.
+# Installs into a caller-owned prefix, so CI and containers need no sudo.
+set -euo pipefail
+
+VERSION=13.0
+TAG=v13_0
+SHA256=c897bbfa9848688982c6d5c30529fc29d68df0b9ff22ffa73bad89db73a7ce49
+PREFIX="${1:-/tmp/rustdv-$(id -u)/iverilog-$VERSION}"
+
+if [ -x "$PREFIX/bin/iverilog" ]; then
+    installed="$("$PREFIX/bin/iverilog" -V 2>/dev/null | sed -n 's/^Icarus Verilog version \([^ ]*\).*/\1/p')"
+    if [ "$installed" = "$VERSION" ]; then
+        echo "Icarus Verilog $VERSION already installed at $PREFIX"
+        exit 0
+    fi
+fi
+
+missing=()
+for tool in curl tar autoconf make flex bison gperf; do
+    command -v "$tool" >/dev/null 2>&1 || missing+=("$tool")
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+    echo "Icarus Verilog build dependencies missing: ${missing[*]}" >&2
+    exit 2
+fi
+
+SCRATCH="/tmp/rustdv-$(id -u)/iverilog-install"
+ARCHIVE="$SCRATCH/iverilog-v$VERSION.tar.gz"
+mkdir -p "$SCRATCH" "$PREFIX"
+
+if [ ! -f "$ARCHIVE" ]; then
+    curl --fail --location --silent --show-error \
+        "https://github.com/steveicarus/iverilog/archive/refs/tags/$TAG.tar.gz" \
+        --output "$ARCHIVE"
+fi
+
+if command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')"
+elif command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$ARCHIVE" | awk '{print $1}')"
+else
+    echo "Icarus Verilog installer needs shasum or sha256sum" >&2
+    exit 2
+fi
+if [ "$actual" != "$SHA256" ]; then
+    echo "Icarus Verilog archive checksum mismatch: got $actual, expected $SHA256" >&2
+    exit 1
+fi
+
+SOURCE="$(mktemp -d "$SCRATCH/source.XXXXXX")"
+trap 'rm -rf "$SOURCE"' EXIT
+tar -xzf "$ARCHIVE" -C "$SOURCE" --strip-components=1
+
+jobs="${ICARUS_BUILD_JOBS:-2}"
+(
+    cd "$SOURCE"
+    # The release driver uses _NSGetExecutablePath without including its
+    # declaration. Supply the Apple header when compiling on macOS.
+    if [ "$(uname -s)" = Darwin ]; then
+        export CFLAGS="${CFLAGS:--g -O2} -include mach-o/dyld.h"
+    fi
+    sh autoconf.sh
+    ./configure --prefix="$PREFIX"
+    make -j "$jobs"
+    make install
+)
+
+"$PREFIX/bin/iverilog" -V

--- a/output/regression/TESTING.md
+++ b/output/regression/TESTING.md
@@ -87,11 +87,18 @@ regression.
   The simulator smoke tests (`tests/sim-*`) use this: they run where
   Icarus/Verilator are installed (including CI) and skip elsewhere.
 
+When a custom test is missing an expected output marker, the runner prints
+the captured command output after the failure summary so the underlying
+simulator assertion is visible in CI.
+
 ## Continuous integration
 
 `.github/workflows/ci.yml` runs the full no-simulator regression plus a
 free-simulator matrix. Linux runs the Icarus and Verilator entries; macOS
 repeats the Verilator runtime, scheduler, DEBUG/FST, and mutation entries.
+Both simulator jobs build and cache Icarus 13.0 via `ci/install-iverilog.sh`.
+Icarus 12 has a next-time callback re-registration bug exercised by the phase
+regression; CI verifies the selected version before running tests.
 Commercial simulators cannot run in public CI; license-holders run
 `sim/run_smoke.sh <sim>` locally.
 
@@ -160,6 +167,14 @@ rustdv/framework-tests/run.sh conc     # one group
 TinyALU's XOR to an OR, requires two testbenches to **fail**, then requires
 both to pass again on the real RTL. A scoreboard that cannot fail is not a
 scoreboard.
+
+The trigger group also checks that phase futures complete only after their own
+callback: repeated polls, sibling wakeups through `join_all` and the component
+runner, settled combinational data, ReadWrite write ordering, next-timestep
+advancement, cancellation, latest-waker replacement, consecutive callback
+batches, and illegal ReadOnly operations. These tests run on both Icarus and
+Verilator. Restoring the old registration-as-completion behavior must fail
+`custom/sim-triggers`.
 
 The Verilator entries add a host-scheduler contract, the full TinyALU Rust
 testbench, selected-internal DEBUG/FST output, and the same mutation check.

--- a/output/regression/regress.py
+++ b/output/regression/regress.py
@@ -332,6 +332,8 @@ def suite_custom(args):
             missing = [s for s in spec["expect_in_output"] if s not in hay]
             if missing:
                 record(tid, False, f"output missing: {missing}")
+                print("    captured simulator/command output:")
+                print(hay.rstrip())
                 continue
         if spec.get("golden"):
             gp = os.path.join(os.path.dirname(spec_path), spec["golden"])

--- a/output/regression/tests/sim-scheduler-verilator/test.json
+++ b/output/regression/tests/sim-scheduler-verilator/test.json
@@ -5,13 +5,16 @@
   "skip_if_missing": "verilator",
   "env": {
     "SIM": "verilator",
-    "RUSTDV_TESTCASE": "trig_,clock_,conc_,elab_,runner_,sig_widths,sig_round_trips,sig_truncates,sig_reads,sig_missing"
+    "RUSTDV_TESTCASE": "trig_,TrigPhase,clock_,conc_,elab_,runner_,sig_widths,sig_round_trips,sig_truncates,sig_reads,sig_missing"
   },
   "expect_exit": 0,
   "timeout": 600,
   "expect_in_output": [
-    "rustdv: found 37 test(s)",
+    "rustdv: found 43 test(s)",
     "trig_timer_advances_exactly PASSED",
+    "TrigPhaseComponentSettledData PASSED",
+    "trig_phase_repoll_requires_callback PASSED",
+    "trig_phase_batch_cancellation_and_latest_waker PASSED",
     "trig_earliest_rtl_or_vpi_deadline_wins PASSED",
     "trig_at_end_write_settles_before_read_only PASSED",
     "trig_read_only_sees_settled_rtl PASSED",

--- a/output/regression/tests/sim-triggers/test.json
+++ b/output/regression/tests/sim-triggers/test.json
@@ -5,5 +5,5 @@
   "env": { "RUSTDV_TESTCASE": "trig" },
   "skip_if_missing": "iverilog",
   "expect_exit": 0,
-  "expect_in_output": ["REGRESSION: PASS"]
+  "expect_in_output": ["REGRESSION: PASS", "TrigPhaseComponentSettledData PASSED", "trig_phase_repoll_requires_callback PASSED", "trig_phase_join_all_sibling_wakeup PASSED", "trig_phase_batch_cancellation_and_latest_waker PASSED", "trig_phase_cancel_preserves_scheduled_write PASSED", "trig_phase_read_only_rejects_illegal_operations PASSED"]
 }

--- a/rustdv/framework-tests/src/triggers.rs
+++ b/rustdv/framework-tests/src/triggers.rs
@@ -5,9 +5,17 @@
 //! tests fail one at a time, with the mechanism in the test's name.
 
 use std::cell::Cell;
+use std::future::{Future, poll_fn};
+use std::pin::Pin;
 use std::rc::Rc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+use std::task::{Context, Poll, Wake, Waker};
 
 use rustdv::prelude::*;
+use rustdv::sim::phase::{PhaseFut, SimPhase, current_phase};
 
 use crate::steps_per_ns;
 
@@ -370,5 +378,207 @@ async fn trig_phase_order_within_a_step(ctx: RustdvCtx) -> Result<(), TestError>
 
     next_time_step().await;
     check!(sim_time_ns() > t0, "NextTimeStep did not advance past {t0}");
+    Ok(())
+}
+
+// Phase registrations must survive unrelated parent polls without completing.
+async fn poll_twice_then_wait(mut phase: PhaseFut) {
+    poll_fn(|cx| {
+        assert!(
+            Pin::new(&mut phase).poll(cx).is_pending(),
+            "first phase poll"
+        );
+        assert!(
+            Pin::new(&mut phase).poll(cx).is_pending(),
+            "phase completed before callback"
+        );
+        Poll::Ready(())
+    })
+    .await;
+    phase.await;
+}
+
+#[rustdv::test]
+async fn trig_phase_repoll_requires_callback(ctx: RustdvCtx) -> Result<(), TestError> {
+    Clock::new(&ctx.dut().signal("clk")?, SimDuration::ns(2)).start();
+    poll_twice_then_wait(read_write()).await;
+    assert_eq!(current_phase(), SimPhase::ReadWrite);
+    // Registered during the first callback's drain: requires a new callback.
+    poll_twice_then_wait(read_write()).await;
+    assert_eq!(current_phase(), SimPhase::ReadWrite);
+    poll_twice_then_wait(read_only()).await;
+    assert_eq!(current_phase(), SimPhase::ReadOnly);
+    for _ in 0..2 {
+        let before = rustdv::sim_time_steps();
+        poll_twice_then_wait(next_time_step()).await;
+        assert!(rustdv::sim_time_steps() > before);
+    }
+    Ok(())
+}
+
+async fn sibling_yields() {
+    for _ in 0..4 {
+        NullTrigger::new().await;
+    }
+}
+
+#[rustdv::test]
+async fn trig_phase_join_all_sibling_wakeup(ctx: RustdvCtx) -> Result<(), TestError> {
+    Clock::new(&ctx.dut().signal("clk")?, SimDuration::ns(2)).start();
+    for make in [read_write, read_only, next_time_step] {
+        let done = Cell::new(false);
+        let before = rustdv::sim_time_steps();
+        let futures: Vec<Pin<Box<dyn Future<Output = ()> + '_>>> = vec![
+            Box::pin(async {
+                make().await;
+                done.set(true);
+            }),
+            Box::pin(async {
+                sibling_yields().await;
+                assert!(!done.get(), "sibling polls completed a phase wait");
+                assert_eq!(rustdv::sim_time_steps(), before);
+            }),
+        ];
+        rustdv::sim::combinators::join_all(futures).await;
+        assert!(done.get());
+    }
+    Ok(())
+}
+
+#[derive(Default)]
+struct WakeCount(AtomicUsize);
+impl Wake for WakeCount {
+    fn wake(self: Arc<Self>) {
+        self.0.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+#[rustdv::test]
+async fn trig_phase_batch_cancellation_and_latest_waker(ctx: RustdvCtx) -> Result<(), TestError> {
+    Clock::new(&ctx.dut().signal("clk")?, SimDuration::ns(2)).start();
+    for make in [read_write, read_only, next_time_step] {
+        let old = Arc::new(WakeCount::default());
+        let latest = Arc::new(WakeCount::default());
+        let cancelled = Arc::new(WakeCount::default());
+        let old_waker = Waker::from(old.clone());
+        let latest_waker = Waker::from(latest.clone());
+        let mut survivor = make();
+        let mut second = make();
+        assert!(
+            Pin::new(&mut survivor)
+                .poll(&mut Context::from_waker(&old_waker))
+                .is_pending()
+        );
+        assert!(
+            Pin::new(&mut survivor)
+                .poll(&mut Context::from_waker(&latest_waker))
+                .is_pending()
+        );
+        assert!(
+            Pin::new(&mut second)
+                .poll(&mut Context::from_waker(&latest_waker))
+                .is_pending()
+        );
+        {
+            let waker = Waker::from(cancelled.clone());
+            let mut doomed = make();
+            assert!(
+                Pin::new(&mut doomed)
+                    .poll(&mut Context::from_waker(&waker))
+                    .is_pending()
+            );
+        }
+        assert_eq!(Arc::strong_count(&cancelled), 1, "cancelled waker retained");
+        make().await; // A live task waker drives the same callback batch.
+        assert_eq!(old.0.load(Ordering::SeqCst), 0);
+        assert_eq!(latest.0.load(Ordering::SeqCst), 2);
+        assert_eq!(cancelled.0.load(Ordering::SeqCst), 0);
+        assert!(
+            Pin::new(&mut survivor)
+                .poll(&mut Context::from_waker(&latest_waker))
+                .is_ready()
+        );
+        assert!(
+            Pin::new(&mut second)
+                .poll(&mut Context::from_waker(&latest_waker))
+                .is_ready()
+        );
+    }
+    Ok(())
+}
+
+#[derive(Component, Default)]
+struct PhaseWakeSibling;
+impl Component for PhaseWakeSibling {
+    async fn run(&mut self, ctx: &mut RustdvCtx) -> Result<(), TestError> {
+        let clk = ctx.dut().signal("clk")?;
+        clk.falling_edge().await;
+        sibling_yields().await;
+        Ok(())
+    }
+}
+
+#[rustdv::test]
+#[derive(Component, Default)]
+struct TrigPhaseComponentSettledData {
+    #[component]
+    sibling: RustdvComp,
+}
+impl Component for TrigPhaseComponentSettledData {
+    fn build(&mut self, _ctx: &mut RustdvCtx) {
+        self.sibling = PhaseWakeSibling::new_comp();
+    }
+    async fn run(&mut self, ctx: &mut RustdvCtx) -> Result<(), TestError> {
+        let _objection = ctx.raise_objection("phase sampling");
+        let clk = ctx.dut().signal("clk")?;
+        let input = ctx.dut().signal("comb_in")?;
+        let output = ctx.dut().signal("comb_out")?;
+        Clock::new(&clk, SimDuration::ns(2)).start();
+        clk.falling_edge().await;
+        input.set_u64(0x69);
+        read_write().await;
+        assert_eq!(current_phase(), SimPhase::ReadWrite);
+        assert_eq!(
+            input.get_u64().unwrap(),
+            0x69,
+            "writes must precede waiters"
+        );
+        read_only().await;
+        assert_eq!(current_phase(), SimPhase::ReadOnly);
+        assert_eq!(output.get_u64().unwrap(), 0x69 ^ 0xA5);
+        Ok(())
+    }
+}
+
+#[rustdv::test]
+async fn trig_phase_cancel_preserves_scheduled_write(ctx: RustdvCtx) -> Result<(), TestError> {
+    let sig = ctx.dut().signal("byte_sig")?;
+    sig.set_u64(0x42);
+    let mut doomed = read_write();
+    poll_fn(|cx| {
+        assert!(Pin::new(&mut doomed).poll(cx).is_pending());
+        Poll::Ready(())
+    })
+    .await;
+    drop(doomed);
+    read_only().await;
+    assert_eq!(sig.get_u64().unwrap(), 0x42);
+    Ok(())
+}
+
+#[rustdv::test]
+async fn trig_phase_read_only_rejects_illegal_operations(ctx: RustdvCtx) -> Result<(), TestError> {
+    let sig = ctx.dut().signal("byte_sig")?;
+    read_only().await;
+    for make in [read_write, read_only] {
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            let mut future = make();
+            let _ = Pin::new(&mut future).poll(&mut Context::from_waker(Waker::noop()));
+        }));
+        assert!(result.is_err(), "illegal phase transition accepted");
+    }
+    assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| sig.set_u64(1))).is_err());
+    assert!(std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| sig.set_u64_now(1))).is_err());
+    assert_eq!(current_phase(), SimPhase::ReadOnly);
     Ok(())
 }

--- a/rustdv/rustdv-sim/src/phase.rs
+++ b/rustdv/rustdv-sim/src/phase.rs
@@ -11,13 +11,13 @@
 use std::cell::{Cell, RefCell};
 use std::future::Future;
 use std::pin::Pin;
-use std::rc::Rc;
-use std::task::{Context, Poll, Waker};
+use std::rc::{Rc, Weak};
+use std::task::{Context, Poll};
 
 use rustdv_gpi as gpi;
 use rustdv_gpi::{BigUint, LogicArray};
 
-use crate::executor;
+use crate::{executor, triggers::TrigShared};
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum SimPhase {
@@ -39,11 +39,11 @@ pub(crate) enum WriteVal {
 
 struct Hub {
     phase: Cell<SimPhase>,
-    rw_waiters: RefCell<Vec<Waker>>,
+    rw_waiters: RefCell<Vec<Weak<TrigShared>>>,
     rw_cb: RefCell<Option<gpi::CallbackHandle>>,
-    ro_waiters: RefCell<Vec<Waker>>,
+    ro_waiters: RefCell<Vec<Weak<TrigShared>>>,
     ro_cb: RefCell<Option<gpi::CallbackHandle>>,
-    nt_waiters: RefCell<Vec<Waker>>,
+    nt_waiters: RefCell<Vec<Weak<TrigShared>>>,
     nt_cb: RefCell<Option<gpi::CallbackHandle>>,
     writes: RefCell<Vec<(gpi::LogicHandle, WriteVal)>>,
 }
@@ -160,6 +160,17 @@ pub(crate) fn schedule(h: gpi::LogicHandle, v: WriteVal) {
 // Priming and firing
 // ---------------------------------------------------------------------------
 
+// Detach the batch before waking tasks: waits created during the executor
+// drain belong to a subsequent callback. Weak entries do not retain cancelled
+// futures or their task wakers, and cancellation never removes shared work.
+fn fire_waiters(waiters: &RefCell<Vec<Weak<TrigShared>>>) {
+    for waiter in std::mem::take(&mut *waiters.borrow_mut()) {
+        if let Some(shared) = waiter.upgrade() {
+            shared.fire();
+        }
+    }
+}
+
 fn prime_rw(hub: &Rc<Hub>) {
     if hub.rw_cb.borrow().is_some() {
         return;
@@ -173,9 +184,7 @@ fn prime_rw(hub: &Rc<Hub>) {
         for (sig, val) in &writes {
             apply_write(*sig, val);
         }
-        for w in h.rw_waiters.borrow_mut().drain(..) {
-            w.wake();
-        }
+        fire_waiters(&h.rw_waiters);
         executor::current().run_until_idle();
         h.phase.set(SimPhase::Normal);
     }));
@@ -190,9 +199,7 @@ fn prime_ro(hub: &Rc<Hub>) {
     let cb = gpi::register_read_only(Box::new(move || {
         h.ro_cb.borrow_mut().take();
         h.phase.set(SimPhase::ReadOnly);
-        for w in h.ro_waiters.borrow_mut().drain(..) {
-            w.wake();
-        }
+        fire_waiters(&h.ro_waiters);
         executor::current().run_until_idle();
         h.phase.set(SimPhase::Normal);
     }));
@@ -206,9 +213,7 @@ fn prime_nt(hub: &Rc<Hub>) {
     let h = hub.clone();
     let cb = gpi::register_next_sim_time(Box::new(move || {
         h.nt_cb.borrow_mut().take();
-        for w in h.nt_waiters.borrow_mut().drain(..) {
-            w.wake();
-        }
+        fire_waiters(&h.nt_waiters);
         executor::current().run_until_idle();
     }));
     *hub.nt_cb.borrow_mut() = Some(cb);
@@ -227,37 +232,43 @@ enum PhaseKind {
 
 pub struct PhaseFut {
     kind: PhaseKind,
-    registered: bool,
+    shared: Option<Rc<TrigShared>>,
 }
 
 impl Future for PhaseFut {
     type Output = ();
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-        if self.registered {
-            return Poll::Ready(());
+        if let Some(shared) = &self.shared {
+            if shared.fired() {
+                return Poll::Ready(());
+            }
+            shared.set_waker(cx.waker().clone());
+            return Poll::Pending;
         }
         let hub = hub();
+        let shared = TrigShared::new();
+        shared.set_waker(cx.waker().clone());
         match self.kind {
             PhaseKind::ReadWrite => {
                 if hub.phase.get() == SimPhase::ReadOnly {
                     panic!("awaiting ReadWrite from the ReadOnly phase is illegal (cocotb rule)");
                 }
-                hub.rw_waiters.borrow_mut().push(cx.waker().clone());
+                hub.rw_waiters.borrow_mut().push(Rc::downgrade(&shared));
                 prime_rw(&hub);
             }
             PhaseKind::ReadOnly => {
                 if hub.phase.get() == SimPhase::ReadOnly {
                     panic!("awaiting ReadOnly from the ReadOnly phase is illegal (cocotb rule)");
                 }
-                hub.ro_waiters.borrow_mut().push(cx.waker().clone());
+                hub.ro_waiters.borrow_mut().push(Rc::downgrade(&shared));
                 prime_ro(&hub);
             }
             PhaseKind::NextTimeStep => {
-                hub.nt_waiters.borrow_mut().push(cx.waker().clone());
+                hub.nt_waiters.borrow_mut().push(Rc::downgrade(&shared));
                 prime_nt(&hub);
             }
         }
-        self.registered = true;
+        self.shared = Some(shared);
         Poll::Pending
     }
 }
@@ -266,7 +277,7 @@ impl Future for PhaseFut {
 pub fn read_write() -> PhaseFut {
     PhaseFut {
         kind: PhaseKind::ReadWrite,
-        registered: false,
+        shared: None,
     }
 }
 
@@ -274,7 +285,7 @@ pub fn read_write() -> PhaseFut {
 pub fn read_only() -> PhaseFut {
     PhaseFut {
         kind: PhaseKind::ReadOnly,
-        registered: false,
+        shared: None,
     }
 }
 
@@ -282,6 +293,6 @@ pub fn read_only() -> PhaseFut {
 pub fn next_time_step() -> PhaseFut {
     PhaseFut {
         kind: PhaseKind::NextTimeStep,
-        registered: false,
+        shared: None,
     }
 }


### PR DESCRIPTION
Phase futures could complete when a parent task was polled for an unrelated wakeup, before their simulator callback fired. Track completion per registration so each wait stays pending until its callback is delivered, while preserving scheduled-write ordering and ReadOnly restrictions.

Add simulator coverage for repeated polls, sibling wakeups, settled data, cancellation, waker replacement, and consecutive callbacks. Pin simulator CI to checksum-verified Icarus 13.0: Icarus 12 incorrectly fires re-registered next-time callbacks at the same timestamp. Print captured command output when a regression expectation is missing.

Validation: built Icarus 13.0 on macOS with the new installer and passed custom/sim-triggers without a runtime compatibility workaround. Workflow YAML and shell syntax checks pass.
