### PR TITLE
Add RUSTDV_TOP for explicit top-level module selection

### DIFF
--- a/output/examples/sim-common/run_sim.sh
+++ b/output/examples/sim-common/run_sim.sh
@@ -7,6 +7,7 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 CRATE="$1"; TOP="$2"; shift 2
+export RUSTDV_TOP="$TOP"
 SIM="${SIM:-icarus}"
 HDL=("$@"); [ ${#HDL[@]} -eq 0 ] && HDL=(sim-common/hdl/timescale.v "sim-common/hdl/${TOP}.sv")
 REPO_ROOT="$(cd ../.. && pwd)"

--- a/rustdv/framework-tests/run.sh
+++ b/rustdv/framework-tests/run.sh
@@ -13,6 +13,7 @@ set -euo pipefail
 cd "$(dirname "$0")"
 SIM="${SIM:-icarus}"
 REPO_ROOT="$(cd ../.. && pwd)"
+export RUSTDV_TOP=probe
 
 # Scratch under one per-user root; see output/examples/sim-common/run_sim.sh
 # for why the uid is in the path.

--- a/rustdv/getting-started-with-rustdv.md
+++ b/rustdv/getting-started-with-rustdv.md
@@ -119,7 +119,9 @@ no Verilog testbench at all. The minimum is one crate with:
    defaults to 1-second precision and your nanosecond clock goes wrong.
 4. **`sim/run.sh`** — builds the crate, renames the `.so` to `.vpi`,
    compiles your RTL, runs `vvp`. Adapt the template's three variables:
-   crate name, top module name, RTL file list.
+   crate name, top module name, RTL file list. Export the selected module as
+   `RUSTDV_TOP` before starting the simulator; when it is unset, rustdv uses
+   the first top-level module returned by VPI.
 5. **Your RTL**, unmodified, in `hdl/`.
 
 Run `sim/run.sh`. When you see your smoke test pass, you have a live

--- a/rustdv/rustdv-gpi/src/rustdv_gpi.rs
+++ b/rustdv/rustdv-gpi/src/rustdv_gpi.rs
@@ -600,12 +600,34 @@ pub fn top_modules() -> Vec<HierarchyHandle> {
     out
 }
 
-/// The first top-level module (the DUT in single-top designs).
-pub fn top_module() -> Result<HierarchyHandle, HandleError> {
+fn select_top_module(explicit_name: Option<&str>) -> Result<HierarchyHandle, HandleError> {
+    if let Some(name) = explicit_name {
+        let cname = CString::new(name).expect("NUL in RUSTDV_TOP");
+        let raw = unsafe { sys::vpi_handle_by_name(cname.as_ptr(), std::ptr::null_mut()) };
+        let h = ObjHandle::new(raw).ok_or_else(|| HandleError::NotFound {
+            name: name.to_owned(),
+            scope: "<top-level>".to_owned(),
+        })?;
+        return AnyHandle::classify(h).as_hierarchy();
+    }
+
     top_modules()
         .into_iter()
         .next()
         .ok_or(HandleError::NoTopModule)
+}
+
+/// The configured top-level module, or the first simulator root when no top
+/// was configured.
+///
+/// `RUSTDV_TOP` selects an exact root by name. Without it, the first top-level
+/// module returned by VPI is used.
+pub fn top_module() -> Result<HierarchyHandle, HandleError> {
+    let explicit_name = std::env::var("RUSTDV_TOP")
+        .ok()
+        .map(|name| name.trim().to_owned())
+        .filter(|name| !name.is_empty());
+    select_top_module(explicit_name.as_deref())
 }
 
 // ===========================================================================
@@ -1019,6 +1041,22 @@ mod callback_tests {
 #[cfg(test)]
 mod handle_tests {
     use super::*;
+
+    #[test]
+    fn top_selection_prefers_explicit_name_and_otherwise_uses_first_root() {
+        rustdv_vpi_stubs::configure_top_modules(&["first", "dut"]);
+        assert_eq!(select_top_module(Some("dut")).unwrap().name(), "dut");
+        assert_eq!(select_top_module(None).unwrap().name(), "first");
+        assert!(matches!(
+            select_top_module(Some("missing")),
+            Err(HandleError::NotFound { .. })
+        ));
+        rustdv_vpi_stubs::configure_top_modules(&[]);
+        assert!(matches!(
+            select_top_module(None),
+            Err(HandleError::NoTopModule)
+        ));
+    }
 
     fn make_signal(width: i32, words: &[sys::t_vpi_vecval], binstr: &str) -> LogicHandle {
         rustdv_vpi_stubs::configure_signal(width, words, binstr);

--- a/rustdv/rustdv-sim/src/handle.rs
+++ b/rustdv/rustdv-sim/src/handle.rs
@@ -310,7 +310,7 @@ impl LogicHandle {
     }
 }
 
-/// The first top-level module (the DUT in single-top designs).
+/// The `RUSTDV_TOP` module, or the first top-level module when it is unset.
 pub fn top_module() -> Result<HierarchyHandle, HandleError> {
     Ok(HierarchyHandle {
         raw: gpi::top_module()?,

--- a/rustdv/rustdv-vpi-stubs/src/rustdv_vpi_stubs.rs
+++ b/rustdv/rustdv-vpi-stubs/src/rustdv_vpi_stubs.rs
@@ -27,9 +27,11 @@ use std::ffi::{CStr, CString};
 use std::os::raw::c_void;
 
 use rustdv_gpi_sys::{
-    t_cb_data, t_vpi_value, t_vpi_vecval, vpiBinStrVal, vpiHandle, vpiNet, vpiNoDelay, vpiSize,
-    vpiType, vpiVectorVal,
+    t_cb_data, t_vpi_value, t_vpi_vecval, vpiBinStrVal, vpiFullName, vpiHandle, vpiModule, vpiName,
+    vpiNet, vpiNoDelay, vpiSize, vpiType, vpiVectorVal,
 };
+
+const TOP_HANDLE_BASE: usize = 0x1000;
 
 struct StubCallback {
     data: t_cb_data,
@@ -43,6 +45,11 @@ struct StubSignal {
     vector_value_available: bool,
     binstr: CString,
     last_put: Vec<t_vpi_vecval>,
+}
+
+struct StubTopIterator {
+    next: usize,
+    len: usize,
 }
 
 impl Default for StubSignal {
@@ -61,6 +68,17 @@ thread_local! {
     static CALLBACKS: RefCell<Vec<*mut StubCallback>> = const { RefCell::new(Vec::new()) };
     static PROPERTY_GETS: RefCell<Vec<i32>> = const { RefCell::new(Vec::new()) };
     static SIGNAL: RefCell<StubSignal> = RefCell::new(StubSignal::default());
+    static TOP_MODULES: RefCell<Vec<CString>> = const { RefCell::new(Vec::new()) };
+}
+
+/// Configure the top-level module names returned by the unit-test VPI double.
+pub fn configure_top_modules(names: &[&str]) {
+    TOP_MODULES.with(|modules| {
+        *modules.borrow_mut() = names
+            .iter()
+            .map(|name| CString::new(*name).expect("stub top name contains NUL"))
+            .collect();
+    });
 }
 
 /// Configure the signal value returned by the unit-test VPI double.
@@ -181,21 +199,93 @@ macro_rules! stub {
 }
 
 stub! {
-    vpi_handle_by_name(a: *const i8, b: *mut c_void) -> *mut c_void;
     vpi_handle_by_index(a: *mut c_void, b: i32) -> *mut c_void;
-    vpi_iterate(a: i32, b: *mut c_void) -> *mut c_void;
-    vpi_scan(a: *mut c_void) -> *mut c_void;
-    vpi_get_str(a: i32, b: *mut c_void) -> *mut i8;
     vpi_get_time(a: *mut c_void, b: *mut c_void) -> ();
     vpi_free_object(a: *mut c_void) -> i32;
     vpi_control(a: i32) -> i32;
     vpi_printf(a: *const i8) -> i32;
 }
 
+fn top_handle(index: usize) -> vpiHandle {
+    (TOP_HANDLE_BASE + index) as vpiHandle
+}
+
+fn top_index(handle: vpiHandle) -> Option<usize> {
+    let address = handle as usize;
+    if address >= TOP_HANDLE_BASE {
+        Some(address - TOP_HANDLE_BASE)
+    } else {
+        None
+    }
+}
+
 #[unsafe(no_mangle)]
-pub extern "C" fn vpi_get(property: i32, _handle: *mut c_void) -> i32 {
+pub unsafe extern "C" fn vpi_handle_by_name(name: *const i8, scope: vpiHandle) -> vpiHandle {
+    assert!(!name.is_null(), "vpi_handle_by_name called with null name");
+    assert!(scope.is_null(), "test stub only supports root lookup");
+    let name = unsafe { CStr::from_ptr(name) };
+    TOP_MODULES.with(|modules| {
+        modules
+            .borrow()
+            .iter()
+            .position(|module| module.as_c_str() == name)
+            .map_or(std::ptr::null_mut(), top_handle)
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn vpi_iterate(type_: i32, object: vpiHandle) -> vpiHandle {
+    assert_eq!(type_, vpiModule, "test stub only supports module iteration");
+    assert!(object.is_null(), "test stub only supports root iteration");
+    TOP_MODULES.with(|modules| {
+        let len = modules.borrow().len();
+        if len == 0 {
+            std::ptr::null_mut()
+        } else {
+            Box::into_raw(Box::new(StubTopIterator { next: 0, len })).cast::<c_void>()
+        }
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn vpi_scan(iterator: vpiHandle) -> vpiHandle {
+    assert!(!iterator.is_null(), "vpi_scan called with null iterator");
+    let iterator = iterator.cast::<StubTopIterator>();
+    unsafe {
+        if (*iterator).next == (*iterator).len {
+            drop(Box::from_raw(iterator));
+            std::ptr::null_mut()
+        } else {
+            let handle = top_handle((*iterator).next);
+            (*iterator).next += 1;
+            handle
+        }
+    }
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn vpi_get_str(property: i32, handle: vpiHandle) -> *mut i8 {
+    assert!(
+        property == vpiName || property == vpiFullName,
+        "test stub only supports name properties"
+    );
+    let index = top_index(handle).expect("vpi_get_str called with a non-top handle");
+    TOP_MODULES.with(|modules| {
+        modules
+            .borrow()
+            .get(index)
+            .expect("vpi_get_str called with an unknown top handle")
+            .as_ptr()
+            .cast_mut()
+    })
+}
+
+#[unsafe(no_mangle)]
+pub extern "C" fn vpi_get(property: i32, handle: *mut c_void) -> i32 {
     PROPERTY_GETS.with(|gets| gets.borrow_mut().push(property));
-    if property == vpiType {
+    if property == vpiType && top_index(handle).is_some() {
+        vpiModule
+    } else if property == vpiType {
         vpiNet
     } else if property == vpiSize {
         SIGNAL.with(|signal| signal.borrow().width)

--- a/sim/run_rustdv.sh
+++ b/sim/run_rustdv.sh
@@ -44,19 +44,20 @@ LIB="$CARGO_TARGET_DIR/$PROFDIR/libtinyalu_tb.so"          # Linux
 [ -f "$LIB" ] || LIB="$CARGO_TARGET_DIR/$PROFDIR/libtinyalu_tb.dylib"  # macOS
 export RUSTDV_RANDOM_SEED="${RUSTDV_RANDOM_SEED:-1}"
 export RUSTDV_RESULTS_XML="${RUSTDV_RESULTS_XML:-$BUILD/results.xml}"
+export RUSTDV_TOP=tinyalu
 
 case "$SIM" in
   icarus)
     cp "$LIB" "$BUILD/tinyalu_tb.vpi"
     # timescale.v first: it sets 1ns/1ns for everything after it.
-    iverilog -g2012 -o "$BUILD/tinyalu_rustdv.vvp" -s tinyalu hdl/timescale.v hdl/tinyalu.sv
+    iverilog -g2012 -o "$BUILD/tinyalu_rustdv.vvp" -s "$RUSTDV_TOP" hdl/timescale.v hdl/tinyalu.sv
     vvp -M "$BUILD" -m tinyalu_tb "$BUILD/tinyalu_rustdv.vvp"
     ;;
   verilator)
     if [ "${RUSTDV_VERILATOR_MODE:-fast}" = debug ]; then
       export RUSTDV_VERILATOR_CONTROL_FILE="${RUSTDV_VERILATOR_CONTROL_FILE:-$REPO_ROOT/sim/verilator-debug.vlt}"
     fi
-    "$REPO_ROOT/sim/run_verilator.sh" "$LIB" tinyalu "$BUILD/verilator" \
+    "$REPO_ROOT/sim/run_verilator.sh" "$LIB" "$RUSTDV_TOP" "$BUILD/verilator" \
       "$REPO_ROOT/sim/hdl/timescale.v" "$REPO_ROOT/sim/hdl/tinyalu.sv"
     ;;
   *)

--- a/sim/run_verilator.sh
+++ b/sim/run_verilator.sh
@@ -17,6 +17,7 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LIB="$1"
 TOP="$2"
+export RUSTDV_TOP="$TOP"
 BUILD="$3"
 shift 3
 HDL=("$@")


### PR DESCRIPTION
Allow RUSTDV_TOP to select the DUT by name instead of relying on simulator root ordering. When it is unset or blank, retain the existing behavior of selecting the first top-level module returned by VPI. An explicit name that cannot be found returns an error.

Export the selected top from simulator launch scripts, update the getting-started documentation, and add unit coverage for explicit selection, first-root fallback, missing names, and no roots.
