### PR TITLE
Support real, string, and aggregate VPI handles

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1412,3 +1412,40 @@ installer, verified its already-installed path, and passed `custom/sim-triggers`
 with the original phase implementation. Workflow YAML and shell syntax checks
 pass. The macOS build supplies the Apple executable-path header through CFLAGS
 because the release driver does not include its declaration.
+
+## 2026-09-06 — typed VPI real/string and aggregate handles
+
+Added `RealHandle` and `StringHandle` with immediate reads, scheduled writes,
+and immediate writes. The shared write scheduler preserves ReadOnly guards for
+all value types; strings own their data and reject embedded NUL bytes.
+`AggregateHandle` exposes named and iterated members of unpacked structs/unions,
+including nested aggregates. The facade exports these handles, and wrong-kind
+lookups return `HandleError`.
+
+Six `sv_types_` simulator tests run through the Verilator-only feature and
+`custom/sim-sv-types-verilator` regression entry. Verified on the active macOS
+Verilator development build: real precision, string round trips, scheduling,
+ReadOnly guards, mixed/nested struct members, and union aliasing. Existing
+Verilator scheduler regression and Icarus signal tests also passed, along with
+workspace unit/doc tests, Clippy (existing warnings), and book-listing checks.
+API examples and the unpacked-aggregate VPI requirement are documented in
+`rustdv/framework-tests/README.md`.
+
+## 2026-09-06 — simulator handle modules
+
+Moved `HierarchyHandle`, `LogicHandle`, `RealHandle`, `StringHandle`, and
+`AggregateHandle` into individual modules under `rustdv-sim/src/handle/`.
+`AnyHandle` remains in `handle.rs`, which re-exports all concrete handles and
+`top_module` so existing imports keep working. Preserved the logic-handle
+`From` conversion and lookup behavior. Workspace tests and Clippy pass
+(existing warnings only).
+
+## 2026-09-06 — fallible simulator handle conversions
+
+Changed the five `SimHandle::as_*` conversions from `Option` to `Result`.
+Wrong-kind errors include the object name and expected/actual kinds; the
+metadata-free `Other` variant reports an unknown name. Updated the SV tests
+and API examples for the `SimHandle` rename and aggregate child conversions.
+Added simulator assertions for all five wrong-kind conversion paths, successful
+conversions, and `Other` rejection. Workspace tests, Clippy (existing warnings),
+and book-listing checks pass.

--- a/book-pdf/chapter-notes.md
+++ b/book-pdf/chapter-notes.md
@@ -373,4 +373,17 @@ nothing — and `Eq` adds that promise. It bites a verification engineer in one
 specific place: `HashSet` requires `Eq`, so a transaction carrying a *measured*
 value like a float delay cannot be a coverage key.
 
+## Framework addition: typed VPI variables (2026-09-06)
+
+The framework now exposes `RealHandle`, `StringHandle`, and `AggregateHandle`
+through `dut.real()`, `dut.string()`, and `dut.aggregate()`. Real/string writes
+follow the existing scheduled/immediate phase rules. Unpacked structs/unions
+are accessed by typed members, including nested aggregates. Existing logic-only
+book listings are unchanged; API examples and Verilator coverage are in
+`rustdv/framework-tests/README.md`.
+
+The simulator handle enum is now `SimHandle`. Its `as_hierarchy`, `as_signal`,
+`as_real`, `as_string`, and `as_aggregate` conversions return `Result` with
+`HandleError::WrongKind`; aggregate access uses `child(name)?.as_*()?`.
+
 - API maintenance: `LogicArray::bit(index)` is replaced by `array[index]`, preserving `Option<Logic>` and `None` for out-of-bounds access. No manuscript call sites required updates.

--- a/output/regression/TESTING.md
+++ b/output/regression/TESTING.md
@@ -218,3 +218,12 @@ transcripts**?" — useful when editing the manuscript. `regress.py` answers
 "did anything change since the **last blessed state**?" — that's the
 regression guard. check.sh compares against prose that may contain errata;
 regress.py compares against reality you approved.
+
+### Verilator typed variables
+
+`custom/sim-sv-types-verilator` runs `sv_types_` with the runner's
+`verilator-types` feature. It exercises real/string VPI reads and writes,
+scheduled-write timing, ReadOnly rejection, unpacked struct/union member
+iteration, nested lookup, and union aliasing. See
+[`rustdv/framework-tests/README.md`](../../rustdv/framework-tests/README.md)
+for the API and simulator capability requirement.

--- a/output/regression/tests/sim-sv-types-verilator/test.json
+++ b/output/regression/tests/sim-sv-types-verilator/test.json
@@ -1,0 +1,20 @@
+{
+  "comment": "Verilator real/string access, unpacked struct/union members, write scheduling and ReadOnly guards.",
+  "cmd": ["bash", "rustdv/framework-tests/run.sh", "sv_types_"],
+  "cwd": ".",
+  "skip_if_missing": "verilator",
+  "env": { "SIM": "verilator" },
+  "expect_exit": 0,
+  "timeout": 600,
+  "expect_in_output": [
+    "rustdv: found 6 test(s)",
+    "sv_types_scalar_round_trip PASSED",
+    "sv_types_aggregate_members PASSED",
+    "sv_types_real_scheduled_readonly_rejected PASSED",
+    "sv_types_real_immediate_readonly_rejected PASSED",
+    "sv_types_string_scheduled_readonly_rejected PASSED",
+    "sv_types_string_immediate_readonly_rejected PASSED",
+    "REGRESSION: PASS",
+    "RTL FINAL: PASS"
+  ]
+}

--- a/rustdv/framework-tests/Cargo.toml
+++ b/rustdv/framework-tests/Cargo.toml
@@ -18,3 +18,7 @@ rustdv = { path = ".." }
 
 [dev-dependencies]
 rustdv-vpi-stubs = { path = "../rustdv-vpi-stubs" }
+
+[features]
+# Enabled by run.sh only for Verilator's unpacked aggregate VPI tests.
+verilator-types = []

--- a/rustdv/framework-tests/README.md
+++ b/rustdv/framework-tests/README.md
@@ -1,0 +1,57 @@
+# Framework simulator tests
+
+Run all Icarus tests with `bash rustdv/framework-tests/run.sh`, or select a
+prefix such as `sig_`. Verilator's real/string and unpacked aggregate tests run
+with:
+
+```sh
+SIM=verilator bash rustdv/framework-tests/run.sh sv_types_
+```
+
+The runner enables the `verilator-types` Cargo feature for Verilator. These tests
+require a Verilator build that exposes unpacked structs and unions through VPI
+(`vpiStructVar`, `vpiUnionVar`, and `vpiMember`); the older implementation that
+only exposes scalar variables cannot run them. The regression entry is
+`custom/sim-sv-types-verilator`.
+
+## Typed variable access
+
+`HierarchyHandle` provides `real(name)`, `string(name)`, `aggregate(name)`, and
+`signal(name)`. Both hierarchy and aggregate handles provide `child(name)`.
+Missing names return `HandleError`. `SimHandle` distinguishes `Real`, `String`, `Struct`, and `Union`,
+with `as_hierarchy()`, `as_signal()`, `as_real()`, `as_string()`, and
+`as_aggregate()` conversions returning `Result<H, HandleError>`. Wrong kinds
+return `HandleError::WrongKind` with the name, expected kind, and actual kind.
+`SimHandle::Other` has no object metadata, so its error uses `<unknown>` as the name.
+
+```rust,ignore
+let dut = ctx.dut();
+let gain = dut.real("real_sig")?;
+let label = dut.string("string_sig")?;
+let record = dut.aggregate("record_sig")?;
+gain.set(1.25);
+label.set("ready")?;
+record.child("number")?.as_signal()?.set_u32(42);
+record.child("fraction")?.as_real()?.set(0.5);
+record.child("text")?.as_string()?.set("member")?;
+read_write().await;
+assert_eq!(gain.get()?, 1.25);
+assert_eq!(label.get()?, "ready");
+```
+
+Real and string handles have `get()`, scheduled `set()`, and immediate
+`set_now()`. Scheduled writes own their data, preserve the order of distinct
+handles, and keep the last value written to a handle. Writes during ReadWrite
+apply immediately; both write paths reject ReadOnly. Real values use `f64`.
+Strings are copied from VPI into owned Rust strings (invalid UTF-8 is replaced);
+embedded NUL bytes are rejected before writes.
+
+Structs and unions expose `child(name)` and `children()` for members, including
+nested aggregates. Values are read and written through the member's typed
+handle. Union members share storage. Packed aggregates exposed by the simulator
+as `vpiReg` or `vpiBitVar` continue to use `LogicHandle`.
+
+The `sv_types_` tests cover scalar type recognition and wrong-kind rejection,
+f64 precision, empty/long/UTF-8 strings, owned reads, NUL rejection, deferred and
+immediate writes, last-write-wins, all four ReadOnly guards, member enumeration,
+nested members, mixed member types, missing members, and union aliasing.

--- a/rustdv/framework-tests/hdl/probe.sv
+++ b/rustdv/framework-tests/hdl/probe.sv
@@ -55,6 +55,17 @@ module probe;
                        rtl_event_request, rtl_event_done,
                        never_driven, never_driven_bus};
 
+`ifdef VERILATOR
+   real real_sig;
+   string string_sig;
+   typedef struct { int number; real fraction; string text; } record_t;
+   typedef struct { record_t inner; int tail; } nested_t;
+   typedef union { int unsigned first; int unsigned second; } overlay_t;
+   record_t record_sig;
+   nested_t nested_sig;
+   overlay_t union_sig;
+`endif
+
    final $display("RTL FINAL: PASS");
 
 endmodule

--- a/rustdv/framework-tests/run.sh
+++ b/rustdv/framework-tests/run.sh
@@ -5,7 +5,7 @@
 #
 # With no argument every test in the crate runs. With one, RUSTDV_TESTCASE
 # selects a group by name prefix — `trig_`, `clock_`, `sig_`, `conc_`,
-# `elab_`, `runner_`, `callback_stress_` — which is how the regression gets
+# `elab_`, `runner_`, `callback_stress_`, `sv_types_` (Verilator only) — which is how the regression gets
 # one entry per mechanism off a single build.
 #
 # Success criterion: prints "REGRESSION: PASS".
@@ -20,7 +20,9 @@ export RUSTDV_TOP=probe
 RUSTDV_TMP="/tmp/rustdv-$(id -u)"
 export CARGO_TARGET_DIR="${CARGO_TARGET_DIR:-$RUSTDV_TMP/target}"
 
-(cd .. && cargo build --release -p framework_tests --quiet)
+BUILD_ARGS=(--release -p framework_tests --quiet)
+if [ "$SIM" = verilator ]; then BUILD_ARGS+=(--features verilator-types); fi
+(cd .. && cargo build "${BUILD_ARGS[@]}")
 
 BUILD="${SIM_BUILD_DIR:-$RUSTDV_TMP/framework-tests}"; mkdir -p "$BUILD"
 LIB="$CARGO_TARGET_DIR/release/libframework_tests.so"            # Linux

--- a/rustdv/framework-tests/src/framework_tests.rs
+++ b/rustdv/framework-tests/src/framework_tests.rs
@@ -35,6 +35,7 @@
 //! | `conc_` | [`concurrency`] | the D82 family, against real time |
 //! | `elab_` | [`elaboration`] | unconnected ports fail before the run phase |
 //! | `runner_` | [`runner`] | timeouts, `expect_error`, per-test freshness |
+//! | `sv_types_` | `sv_types` (Verilator feature) | real/string writes and aggregate members |
 //! | `callback_stress_` | [`callback_lifecycle`] | fired one-shot handles reach an RSS plateau |
 //!
 //! The DUT is `hdl/probe.sv`: a clock, signals of known widths that nothing
@@ -77,6 +78,8 @@ pub mod concurrency;
 pub mod elaboration;
 pub mod runner;
 pub mod signals;
+#[cfg(feature = "verilator-types")]
+pub mod sv_types;
 pub mod triggers;
 
 #[cfg(test)]

--- a/rustdv/framework-tests/src/sv_types.rs
+++ b/rustdv/framework-tests/src/sv_types.rs
@@ -1,0 +1,197 @@
+//! Verilator VPI tests for real/string variables and unpacked aggregates.
+use rustdv::prelude::*;
+use rustdv::{SimHandle, ValueError};
+use std::panic::{AssertUnwindSafe, catch_unwind};
+
+#[rustdv::test]
+async fn sv_types_scalar_round_trip(ctx: RustdvCtx) -> Result<(), TestError> {
+    let dut = ctx.dut();
+    check!(
+        matches!(dut.child("real_sig")?, SimHandle::Real(_)),
+        "real type"
+    );
+    check!(
+        matches!(dut.child("string_sig")?, SimHandle::String(_)),
+        "string type"
+    );
+    check!(dut.signal("real_sig").is_err(), "real accepted as logic");
+    check!(dut.real("string_sig").is_err(), "string accepted as real");
+    let hierarchy = SimHandle::Hierarchy(dut).as_hierarchy()?;
+    let real_object = hierarchy.child("real_sig")?;
+    for (error, expected, actual) in [
+        (real_object.as_hierarchy().err(), "module", "real"),
+        (real_object.as_signal().err(), "signal", "real"),
+        (real_object.as_string().err(), "string", "real"),
+        (real_object.as_aggregate().err(), "struct or union", "real"),
+        (
+            hierarchy.child("string_sig")?.as_real().err(),
+            "real",
+            "string",
+        ),
+    ] {
+        check!(
+            matches!(error, Some(HandleError::WrongKind { name, expected: got, actual: kind })
+            if name.ends_with("_sig") && got == expected && kind == actual),
+            "wrong-kind conversion lost error details"
+        );
+    }
+    check!(
+        matches!(
+            SimHandle::Other.as_signal(),
+            Err(HandleError::WrongKind { .. })
+        ),
+        "Other converted to signal"
+    );
+    let real = dut.child("real_sig")?.as_real()?;
+    let text = dut.child("string_sig")?.as_string()?;
+    let precise = 1.0 + 2.0_f64.powi(-40);
+    real.set_now(precise);
+    check!(real.get()? == precise, "real lost f64 precision");
+    let long_text = "long text λ ".repeat(100);
+    text.set_now(&long_text)?;
+    check!(text.get()? == long_text, "long UTF-8 string was truncated");
+    real.set_now(-1.25);
+    text.set_now("initial")?;
+    check!(real.get()? == -1.25, "immediate real write");
+    check!(text.get()? == "initial", "immediate string write");
+    let saved = text.get()?;
+    real.set(123.5);
+    real.set(-0.0625);
+    text.set(&"long text λ ".repeat(100))?;
+    text.set("final λ")?;
+    check!(
+        real.get()? == -1.25 && text.get()? == "initial",
+        "scheduled writes applied early"
+    );
+    read_write().await;
+    check!(
+        real.get()? == -0.0625 && text.get()? == "final λ",
+        "last scheduled write did not win"
+    );
+    check!(saved == "initial", "string read did not own its data");
+    text.set("")?;
+    check!(text.get()?.is_empty(), "ReadWrite write was not immediate");
+    check!(
+        text.set("bad\0text") == Err(ValueError::InteriorNul),
+        "scheduled NUL accepted"
+    );
+    check!(
+        text.set_now("bad\0text") == Err(ValueError::InteriorNul),
+        "immediate NUL accepted"
+    );
+    check!(text.get()?.is_empty(), "invalid string modified value");
+    Ok(())
+}
+
+#[rustdv::test]
+async fn sv_types_aggregate_members(ctx: RustdvCtx) -> Result<(), TestError> {
+    let dut = ctx.dut();
+    check!(
+        matches!(dut.child("record_sig")?, SimHandle::Struct(_)),
+        "struct type"
+    );
+    check!(
+        matches!(dut.child("union_sig")?, SimHandle::Union(_)),
+        "union type"
+    );
+    let record = dut.child("record_sig")?.as_aggregate()?;
+    check!(record.child("missing").is_err(), "missing member found");
+    check!(
+        record.child("fraction")?.as_signal().is_err(),
+        "real member accepted as logic"
+    );
+    let members = record.children();
+    check!(
+        members.len() == 3,
+        "expected three struct members, got {}",
+        members.len()
+    );
+    check!(
+        members
+            .iter()
+            .filter(|h| matches!(h, SimHandle::Real(_)))
+            .count()
+            == 1,
+        "real member missing"
+    );
+    check!(
+        members
+            .iter()
+            .filter(|h| matches!(h, SimHandle::String(_)))
+            .count()
+            == 1,
+        "string member missing"
+    );
+    let number = record.child("number")?.as_signal()?;
+    let fraction = record.child("fraction")?.as_real()?;
+    let text = record.child("text")?.as_string()?;
+    number.set_u32(42);
+    fraction.set(2.75);
+    text.set("member value")?;
+    let nested = dut
+        .aggregate("nested_sig")?
+        .child("inner")?
+        .as_aggregate()?;
+    nested.child("number")?.as_signal()?.set_u32(91);
+    let union = dut.child("union_sig")?.as_aggregate()?;
+    check!(union.children().len() == 2, "union members missing");
+    let first = union.child("first")?.as_signal()?;
+    let second = union.child("second")?.as_signal()?;
+    first.set_u32(0x12345678);
+    read_write().await;
+    check!(number.get_u32()? == 42, "integer struct member");
+    check!(fraction.get()? == 2.75, "real struct member");
+    check!(text.get()? == "member value", "string struct member");
+    check!(
+        nested.child("number")?.as_signal()?.get_u32()? == 91,
+        "nested member"
+    );
+    check!(
+        second.get_u32()? == 0x12345678,
+        "union members do not alias"
+    );
+    second.set_u32_now(0x87654321);
+    check!(first.get_u32()? == 0x87654321, "reverse union alias");
+    Ok(())
+}
+
+#[rustdv::test]
+async fn sv_types_real_scheduled_readonly_rejected(ctx: RustdvCtx) -> Result<(), TestError> {
+    let h = ctx.dut().real("real_sig")?;
+    read_only().await;
+    check!(
+        catch_unwind(AssertUnwindSafe(|| h.set(1.0))).is_err(),
+        "scheduled real write allowed in ReadOnly"
+    );
+    Ok(())
+}
+#[rustdv::test]
+async fn sv_types_real_immediate_readonly_rejected(ctx: RustdvCtx) -> Result<(), TestError> {
+    let h = ctx.dut().real("real_sig")?;
+    read_only().await;
+    check!(
+        catch_unwind(AssertUnwindSafe(|| h.set_now(1.0))).is_err(),
+        "immediate real write allowed in ReadOnly"
+    );
+    Ok(())
+}
+#[rustdv::test]
+async fn sv_types_string_scheduled_readonly_rejected(ctx: RustdvCtx) -> Result<(), TestError> {
+    let h = ctx.dut().string("string_sig")?;
+    read_only().await;
+    check!(
+        catch_unwind(AssertUnwindSafe(|| h.set("illegal"))).is_err(),
+        "scheduled string write allowed in ReadOnly"
+    );
+    Ok(())
+}
+#[rustdv::test]
+async fn sv_types_string_immediate_readonly_rejected(ctx: RustdvCtx) -> Result<(), TestError> {
+    let h = ctx.dut().string("string_sig")?;
+    read_only().await;
+    check!(
+        catch_unwind(AssertUnwindSafe(|| h.set_now("illegal"))).is_err(),
+        "immediate string write allowed in ReadOnly"
+    );
+    Ok(())
+}

--- a/rustdv/rustdv-gpi-sys/src/rustdv_gpi_sys.rs
+++ b/rustdv/rustdv-gpi-sys/src/rustdv_gpi_sys.rs
@@ -40,6 +40,7 @@ pub const vpiTimePrecision: PLI_INT32 = 12;
 // ---------------------------------------------------------------------------
 // Object type codes (vpi_get(vpiType, ...) results / vpi_iterate types)
 // ---------------------------------------------------------------------------
+// Verilog variable types (vpi_user.h)
 pub const vpiConstant: PLI_INT32 = 7;
 pub const vpiIntegerVar: PLI_INT32 = 25;
 pub const vpiMemory: PLI_INT32 = 29;
@@ -54,7 +55,12 @@ pub const vpiLongIntVar: PLI_INT32 = 610;
 pub const vpiShortIntVar: PLI_INT32 = 611;
 pub const vpiIntVar: PLI_INT32 = 612;
 pub const vpiByteVar: PLI_INT32 = 614;
+pub const vpiStringVar: PLI_INT32 = 616;
 pub const vpiEnumVar: PLI_INT32 = 617;
+pub const vpiStructVar: PLI_INT32 = 618;
+pub const vpiUnionVar: PLI_INT32 = 619;
+/// Iterate members of a struct or union.
+pub const vpiMember: PLI_INT32 = 742;
 pub const vpiBitVar: PLI_INT32 = 620;
 
 // ---------------------------------------------------------------------------

--- a/rustdv/rustdv-gpi/src/rustdv_gpi.rs
+++ b/rustdv/rustdv-gpi/src/rustdv_gpi.rs
@@ -84,6 +84,8 @@ pub enum ValueError {
     FourState(String),
     /// The simulator did not supply the requested value representation.
     Unavailable,
+    /// VPI strings cannot contain embedded NUL bytes.
+    InteriorNul,
     Width {
         want: u32,
         have: usize,
@@ -94,7 +96,8 @@ impl fmt::Display for ValueError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ValueError::FourState(s) => write!(f, "value '{s}' has x/z bits"),
-            ValueError::Unavailable => write!(f, "simulator did not return a vector value"),
+            ValueError::Unavailable => write!(f, "simulator did not return the requested value"),
+            ValueError::InteriorNul => write!(f, "VPI string contains an embedded NUL byte"),
             ValueError::Width { want, have } => {
                 write!(f, "width mismatch: want {want}, have {have}")
             }
@@ -141,6 +144,10 @@ impl ObjHandle {
 pub enum AnyHandle {
     Hierarchy(HierarchyHandle),
     Logic(LogicHandle),
+    Real(RealHandle),
+    String(StringHandle),
+    Struct(AggregateHandle),
+    Union(AggregateHandle),
     Other(ObjHandle),
 }
 
@@ -148,6 +155,10 @@ impl AnyHandle {
     pub fn classify(h: ObjHandle) -> AnyHandle {
         match h.get(sys::vpiType) {
             sys::vpiModule => AnyHandle::Hierarchy(HierarchyHandle { h }),
+            sys::vpiRealVar => AnyHandle::Real(RealHandle { h }),
+            sys::vpiStringVar => AnyHandle::String(StringHandle { h }),
+            sys::vpiStructVar => AnyHandle::Struct(AggregateHandle { h }),
+            sys::vpiUnionVar => AnyHandle::Union(AggregateHandle { h }),
             sys::vpiNet
             | sys::vpiReg
             | sys::vpiIntegerVar
@@ -169,35 +180,58 @@ impl AnyHandle {
         }
     }
 
+    fn object(self) -> ObjHandle {
+        match self {
+            Self::Hierarchy(h) => h.h,
+            Self::Logic(h) => h.h,
+            Self::Real(h) => h.h,
+            Self::String(h) => h.h,
+            Self::Struct(h) | Self::Union(h) => h.h,
+            Self::Other(h) => h,
+        }
+    }
+
+    fn wrong_kind(self, expected: &'static str) -> HandleError {
+        let h = self.object();
+        HandleError::WrongKind {
+            name: h.get_str(sys::vpiFullName),
+            expected,
+            actual: format!("vpiType {}", h.get(sys::vpiType)),
+        }
+    }
+
     pub fn as_logic(self) -> Result<LogicHandle, HandleError> {
         match self {
-            AnyHandle::Logic(l) => Ok(l),
-            AnyHandle::Hierarchy(h) => Err(HandleError::WrongKind {
-                name: h.full_name(),
-                expected: "signal",
-                actual: "module".into(),
-            }),
-            AnyHandle::Other(o) => Err(HandleError::WrongKind {
-                name: o.get_str(sys::vpiFullName),
-                expected: "signal",
-                actual: format!("vpiType {}", o.get(sys::vpiType)),
-            }),
+            Self::Logic(h) => Ok(h),
+            other => Err(other.wrong_kind("signal")),
         }
     }
 
     pub fn as_hierarchy(self) -> Result<HierarchyHandle, HandleError> {
         match self {
-            AnyHandle::Hierarchy(h) => Ok(h),
-            AnyHandle::Logic(l) => Err(HandleError::WrongKind {
-                name: l.full_name(),
-                expected: "module",
-                actual: "signal".into(),
-            }),
-            AnyHandle::Other(o) => Err(HandleError::WrongKind {
-                name: o.get_str(sys::vpiFullName),
-                expected: "module",
-                actual: format!("vpiType {}", o.get(sys::vpiType)),
-            }),
+            Self::Hierarchy(h) => Ok(h),
+            other => Err(other.wrong_kind("module")),
+        }
+    }
+
+    pub fn as_real(self) -> Result<RealHandle, HandleError> {
+        match self {
+            Self::Real(h) => Ok(h),
+            other => Err(other.wrong_kind("real")),
+        }
+    }
+
+    pub fn as_string(self) -> Result<StringHandle, HandleError> {
+        match self {
+            Self::String(h) => Ok(h),
+            other => Err(other.wrong_kind("string")),
+        }
+    }
+
+    pub fn as_aggregate(self) -> Result<AggregateHandle, HandleError> {
+        match self {
+            Self::Struct(h) | Self::Union(h) => Ok(h),
+            other => Err(other.wrong_kind("struct or union")),
         }
     }
 }
@@ -267,6 +301,154 @@ impl HierarchyHandle {
             }
         }
         out
+    }
+
+    pub fn real(&self, name: &str) -> Result<RealHandle, HandleError> {
+        self.child(name)?.as_real()
+    }
+    pub fn string(&self, name: &str) -> Result<StringHandle, HandleError> {
+        self.child(name)?.as_string()
+    }
+    pub fn aggregate(&self, name: &str) -> Result<AggregateHandle, HandleError> {
+        self.child(name)?.as_aggregate()
+    }
+}
+
+/// A simulator real variable.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct RealHandle {
+    h: ObjHandle,
+}
+
+impl RealHandle {
+    pub fn name(&self) -> String {
+        self.h.get_str(sys::vpiName)
+    }
+    pub fn full_name(&self) -> String {
+        self.h.get_str(sys::vpiFullName)
+    }
+    pub fn get(&self) -> Result<f64, ValueError> {
+        let mut value = sys::t_vpi_value {
+            format: sys::vpiRealVal,
+            value: sys::u_vpi_value_union { real: 0.0 },
+        };
+        unsafe {
+            sys::vpi_get_value(self.h.0, &mut value);
+            if value.format != sys::vpiRealVal {
+                return Err(ValueError::Unavailable);
+            }
+            Ok(value.value.real)
+        }
+    }
+    pub fn set_now(&self, value: f64) {
+        let mut value = sys::t_vpi_value {
+            format: sys::vpiRealVal,
+            value: sys::u_vpi_value_union { real: value },
+        };
+        unsafe {
+            sys::vpi_put_value(self.h.0, &mut value, std::ptr::null_mut(), sys::vpiNoDelay);
+        }
+    }
+}
+
+/// A simulator string variable.
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct StringHandle {
+    h: ObjHandle,
+}
+
+impl StringHandle {
+    pub fn name(&self) -> String {
+        self.h.get_str(sys::vpiName)
+    }
+    pub fn full_name(&self) -> String {
+        self.h.get_str(sys::vpiFullName)
+    }
+    pub fn get(&self) -> Result<String, ValueError> {
+        let mut value = sys::t_vpi_value {
+            format: sys::vpiStringVal,
+            value: sys::u_vpi_value_union {
+                str_: std::ptr::null_mut(),
+            },
+        };
+        unsafe {
+            sys::vpi_get_value(self.h.0, &mut value);
+            if value.format != sys::vpiStringVal {
+                return Err(ValueError::Unavailable);
+            }
+            if value.value.str_.is_null() {
+                return Err(ValueError::Unavailable);
+            }
+            Ok(CStr::from_ptr(value.value.str_)
+                .to_string_lossy()
+                .into_owned())
+        }
+    }
+    pub fn set_now(&self, value: &str) -> Result<(), ValueError> {
+        let text = CString::new(value).map_err(|_| ValueError::InteriorNul)?;
+        let mut value = sys::t_vpi_value {
+            format: sys::vpiStringVal,
+            value: sys::u_vpi_value_union {
+                str_: text.as_ptr().cast_mut(),
+            },
+        };
+        unsafe {
+            sys::vpi_put_value(self.h.0, &mut value, std::ptr::null_mut(), sys::vpiNoDelay);
+        }
+        Ok(())
+    }
+}
+
+/// An unpacked struct or union. Read and write through its typed members.
+#[derive(Copy, Clone)]
+pub struct AggregateHandle {
+    h: ObjHandle,
+}
+
+impl AggregateHandle {
+    pub fn name(&self) -> String {
+        self.h.get_str(sys::vpiName)
+    }
+    pub fn full_name(&self) -> String {
+        self.h.get_str(sys::vpiFullName)
+    }
+    pub fn child(&self, name: &str) -> Result<AnyHandle, HandleError> {
+        let path =
+            CString::new(format!("{}.{}", self.full_name(), name)).expect("NUL in member name");
+        let raw = unsafe { sys::vpi_handle_by_name(path.as_ptr(), std::ptr::null_mut()) };
+        ObjHandle::new(raw)
+            .map(AnyHandle::classify)
+            .ok_or_else(|| HandleError::NotFound {
+                name: name.into(),
+                scope: self.full_name(),
+            })
+    }
+    pub fn children(&self) -> Vec<AnyHandle> {
+        let mut out = Vec::new();
+        unsafe {
+            let it = sys::vpi_iterate(sys::vpiMember, self.h.0);
+            if !it.is_null() {
+                while let Some(h) = ObjHandle::new(sys::vpi_scan(it)) {
+                    out.push(AnyHandle::classify(h));
+                }
+            }
+        }
+        out
+    }
+    pub fn signal(&self, name: &str) -> Result<LogicHandle, HandleError> {
+        self.child(name)?.as_logic()
+    }
+}
+
+impl AggregateHandle {
+    pub fn real(&self, name: &str) -> Result<RealHandle, HandleError> {
+        self.child(name)?.as_real()
+    }
+    pub fn string(&self, name: &str) -> Result<StringHandle, HandleError> {
+        self.child(name)?.as_string()
+    }
+    pub fn aggregate(&self, name: &str) -> Result<AggregateHandle, HandleError> {
+        self.child(name)?.as_aggregate()
     }
 }
 
@@ -1041,6 +1223,64 @@ mod callback_tests {
 #[cfg(test)]
 mod handle_tests {
     use super::*;
+
+    #[test]
+    fn sv_integral_variables_support_vector_access() {
+        for object_type in [
+            sys::vpiLongIntVar,
+            sys::vpiShortIntVar,
+            sys::vpiIntVar,
+            sys::vpiByteVar,
+            sys::vpiEnumVar,
+            sys::vpiBitVar,
+        ] {
+            rustdv_vpi_stubs::configure_signal(
+                64,
+                &[
+                    sys::t_vpi_vecval {
+                        aval: 0x89ab_cdef,
+                        bval: 0,
+                    },
+                    sys::t_vpi_vecval {
+                        aval: 0x1234_5678,
+                        bval: 0,
+                    },
+                ],
+                "0",
+            );
+            rustdv_vpi_stubs::configure_signal_type(object_type);
+            let signal = AnyHandle::classify(ObjHandle(1usize as sys::vpiHandle))
+                .as_logic()
+                .unwrap();
+            assert_eq!(signal.size(), 64);
+            assert_eq!(signal.get_u64(), Ok(0x1234_5678_89ab_cdef));
+            signal.set_u64_now(0xfedc_ba98_7654_3210);
+            let words = rustdv_vpi_stubs::last_put_vector();
+            assert_eq!(words[0].aval, 0x7654_3210);
+            assert_eq!(words[1].aval, 0xfedc_ba98);
+        }
+        rustdv_vpi_stubs::configure_signal_type(sys::vpiNet);
+    }
+
+    #[test]
+    fn non_logic_variables_have_typed_handles() {
+        for object_type in [
+            sys::vpiRealVar,
+            sys::vpiStringVar,
+            sys::vpiStructVar,
+            sys::vpiUnionVar,
+        ] {
+            rustdv_vpi_stubs::configure_signal_type(object_type);
+            assert!(matches!(
+                AnyHandle::classify(ObjHandle(1usize as sys::vpiHandle)),
+                AnyHandle::Real(_)
+                    | AnyHandle::String(_)
+                    | AnyHandle::Struct(_)
+                    | AnyHandle::Union(_)
+            ));
+        }
+        rustdv_vpi_stubs::configure_signal_type(sys::vpiNet);
+    }
 
     #[test]
     fn top_selection_prefers_explicit_name_and_otherwise_uses_first_root() {

--- a/rustdv/rustdv-sim/src/clock.rs
+++ b/rustdv/rustdv-sim/src/clock.rs
@@ -1,7 +1,7 @@
 //! Clock generator (port of cocotb `Clock`, mapping row 24).
 
 use crate::executor::{TaskHandle, spawn_named};
-use crate::handle::LogicHandle;
+use crate::handle::{HandleBase, LogicHandle};
 use crate::time::SimDuration;
 use crate::triggers::Timer;
 

--- a/rustdv/rustdv-sim/src/handle.rs
+++ b/rustdv/rustdv-sim/src/handle.rs
@@ -6,313 +6,153 @@
 use rustdv_gpi as gpi;
 pub use rustdv_gpi::{BigUint, HandleError, Logic, LogicArray, ValueError};
 
-use crate::phase;
-use crate::triggers::{Edge, EdgeKind};
+pub mod aggregate;
+pub mod hierarchy;
+pub mod logic;
+pub mod real;
+pub mod string;
 
-/// A module/scope handle: `dut.child("name")?` (OQ-6 dynamic-first lean).
-#[derive(Copy, Clone)]
-pub struct HierarchyHandle {
-    raw: gpi::HierarchyHandle,
-}
-impl HierarchyHandle {
-    /// A handle to nothing, for unit tests that need a `RustdvCtx` but never
-    /// touch the DUT. Any VPI call through it reaches `rustdv-vpi-stubs`,
-    /// which panics — so a test that *does* touch the DUT fails loudly rather
-    /// than reading garbage, and its author learns it belongs in a `sim-*`
-    /// case instead.
-    pub fn null_for_test() -> HierarchyHandle {
-        HierarchyHandle {
-            raw: gpi::HierarchyHandle::null_for_test(),
-        }
-    }
-}
+pub use aggregate::AggregateHandle;
+pub use hierarchy::{HierarchyHandle, top_module};
+pub use logic::LogicHandle;
+pub use real::RealHandle;
+pub use string::StringHandle;
 
-impl HierarchyHandle {
-    pub fn child(&self, name: &str) -> Result<AnyHandle, HandleError> {
-        Ok(AnyHandle::wrap(self.raw.child(name)?))
-    }
-
-    /// Child that must be a signal.
-    pub fn signal(&self, name: &str) -> Result<LogicHandle, HandleError> {
-        Ok(LogicHandle {
-            raw: self.raw.child(name)?.as_logic()?,
-        })
-    }
-
-    pub fn name(&self) -> String {
-        self.raw.name()
-    }
-    pub fn full_name(&self) -> String {
-        self.raw.full_name()
-    }
-
-    pub fn children(&self) -> Vec<AnyHandle> {
-        self.raw
-            .children()
-            .into_iter()
-            .map(AnyHandle::wrap)
-            .collect()
-    }
-}
+use crate::triggers::Edge;
 
 #[derive(Copy, Clone)]
-pub enum AnyHandle {
+pub enum SimHandle {
     Hierarchy(HierarchyHandle),
     Logic(LogicHandle),
+    Real(RealHandle),
+    String(StringHandle),
+    Struct(AggregateHandle),
+    Union(AggregateHandle),
     Other,
 }
 
-impl AnyHandle {
-    fn wrap(h: gpi::AnyHandle) -> AnyHandle {
+impl SimHandle {
+    fn wrap(h: gpi::AnyHandle) -> SimHandle {
         match h {
-            gpi::AnyHandle::Hierarchy(h) => AnyHandle::Hierarchy(HierarchyHandle { raw: h }),
-            gpi::AnyHandle::Logic(l) => AnyHandle::Logic(LogicHandle { raw: l }),
-            gpi::AnyHandle::Other(_) => AnyHandle::Other,
+            gpi::AnyHandle::Hierarchy(raw) => SimHandle::Hierarchy(HierarchyHandle { raw }),
+            gpi::AnyHandle::Logic(raw) => SimHandle::Logic(LogicHandle { raw }),
+            gpi::AnyHandle::Real(raw) => SimHandle::Real(RealHandle { raw }),
+            gpi::AnyHandle::String(raw) => SimHandle::String(StringHandle { raw }),
+            gpi::AnyHandle::Struct(raw) => SimHandle::Struct(AggregateHandle { raw }),
+            gpi::AnyHandle::Union(raw) => SimHandle::Union(AggregateHandle { raw }),
+            gpi::AnyHandle::Other(_) => SimHandle::Other,
         }
     }
 
-    pub fn as_logic(self) -> Option<LogicHandle> {
+    fn wrong_kind(self, expected: &'static str) -> HandleError {
+        let (name, actual) = match self {
+            Self::Hierarchy(h) => (h.full_name(), "module"),
+            Self::Logic(h) => (h.full_name(), "signal"),
+            Self::Real(h) => (h.full_name(), "real"),
+            Self::String(h) => (h.full_name(), "string"),
+            Self::Struct(h) => (h.full_name(), "struct"),
+            Self::Union(h) => (h.full_name(), "union"),
+            // Other carries no underlying object metadata.
+            Self::Other => ("<unknown>".into(), "unsupported simulator object"),
+        };
+        HandleError::WrongKind {
+            name,
+            expected,
+            actual: actual.into(),
+        }
+    }
+
+    pub fn as_hierarchy(self) -> Result<HierarchyHandle, HandleError> {
         match self {
-            AnyHandle::Logic(l) => Some(l),
-            _ => None,
+            SimHandle::Hierarchy(h) => Ok(h),
+            other => Err(other.wrong_kind("module")),
         }
     }
-    pub fn as_hierarchy(self) -> Option<HierarchyHandle> {
+
+    pub fn as_signal(self) -> Result<LogicHandle, HandleError> {
         match self {
-            AnyHandle::Hierarchy(h) => Some(h),
-            _ => None,
+            SimHandle::Logic(l) => Ok(l),
+            other => Err(other.wrong_kind("signal")),
         }
     }
-}
 
-/// A value-bearing signal. Explicit `get()`/`set()` (mapping row 20 —
-/// cocotb 2.x itself moved off the `.value` property).
-#[derive(Copy, Clone, PartialEq, Eq)]
-pub struct LogicHandle {
-    raw: gpi::LogicHandle,
-}
+    pub fn as_real(self) -> Result<RealHandle, HandleError> {
+        match self {
+            Self::Real(h) => Ok(h),
+            other => Err(other.wrong_kind("real")),
+        }
+    }
 
-impl std::fmt::Debug for LogicHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "LogicHandle(\"{}\")", self.full_name())
+    pub fn as_string(self) -> Result<StringHandle, HandleError> {
+        match self {
+            Self::String(h) => Ok(h),
+            other => Err(other.wrong_kind("string")),
+        }
+    }
+
+    pub fn as_aggregate(self) -> Result<AggregateHandle, HandleError> {
+        match self {
+            Self::Struct(h) | Self::Union(h) => Ok(h),
+            other => Err(other.wrong_kind("struct or union")),
+        }
+    }
+
+    pub fn is_other(self) -> bool {
+        matches!(self, SimHandle::Other)
     }
 }
 
-impl std::fmt::Debug for HierarchyHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "HierarchyHandle(\"{}\")", self.full_name())
+/// A trait for the common methods of all handle types
+pub trait HandleBase {
+    /// Get the name of the handle (without hierarchy)
+    fn name(&self) -> String;
+
+    /// Get the full name of the handle (with hierarchy)
+    fn full_name(&self) -> String;
+}
+
+/// A trait for handles that have children (hierarchy, aggregate)
+pub trait HandleChildren {
+    /// Get a child handle by name
+    fn child(&self, name: &str) -> Result<SimHandle, HandleError>;
+
+    /// Get all child handles
+    fn children(&self) -> Vec<SimHandle>;
+
+    /// Get a child handle by name and convert it to logic handle
+    fn signal(&self, name: &str) -> Result<LogicHandle, HandleError> {
+        self.child(name)?.as_signal()
+    }
+
+    /// Get a child handle by name and convert it to real handle
+    fn real(&self, name: &str) -> Result<RealHandle, HandleError> {
+        self.child(name)?.as_real()
+    }
+
+    /// Get a child handle by name and convert it to string handle
+    fn string(&self, name: &str) -> Result<StringHandle, HandleError> {
+        self.child(name)?.as_string()
+    }
+
+    /// Get a child handle by name and convert it to hierarchy handle
+    fn hierarchy(&self, name: &str) -> Result<HierarchyHandle, HandleError> {
+        self.child(name)?.as_hierarchy()
+    }
+
+    /// Get a child handle by name and convert it to aggregate handle
+    fn aggregate(&self, name: &str) -> Result<AggregateHandle, HandleError> {
+        self.child(name)?.as_aggregate()
     }
 }
 
-impl LogicHandle {
-    pub fn name(&self) -> String {
-        self.raw.name()
-    }
-    pub fn full_name(&self) -> String {
-        self.raw.full_name()
-    }
-    pub fn size(&self) -> u32 {
-        self.raw.size()
-    }
+/// A trait for handles that have observable events
+pub trait HandleEvent {
+    /// Get the rising edge event for this handle
+    fn rising_edge(&self) -> Edge;
 
-    // ----------------- Read: current value (mapping row 19) -----------------
+    /// Get the falling edge event for this handle
+    fn falling_edge(&self) -> Edge;
 
-    /// Current boolean value, or `Err` if VPI does not supply it.
-    pub fn get_bool(&self) -> Result<bool, ValueError> {
-        self.raw.get_bool()
-    }
-
-    /// Current unsigned 8-bit value, or `Err` if VPI does not supply it.
-    pub fn get_u8(&self) -> Result<u8, ValueError> {
-        self.raw.get_u8()
-    }
-    /// Current unsigned 16-bit value, or `Err` if VPI does not supply it.
-    pub fn get_u16(&self) -> Result<u16, ValueError> {
-        self.raw.get_u16()
-    }
-
-    /// Current unsigned 32-bit value, or `Err` if VPI does not supply it.
-    pub fn get_u32(&self) -> Result<u32, ValueError> {
-        self.raw.get_u32()
-    }
-
-    /// Current unsigned 64-bit value, or `Err` if VPI does not supply it.
-    pub fn get_u64(&self) -> Result<u64, ValueError> {
-        self.raw.get_u64()
-    }
-
-    /// Current unsigned 128-bit value, or `Err` if VPI does not supply it.
-    pub fn get_u128(&self) -> Result<u128, ValueError> {
-        self.raw.get_u128()
-    }
-
-    /// Current arbitrary-width unsigned value, or `Err` if VPI does not supply it.
-    pub fn get_bigint(&self) -> Result<BigUint, ValueError> {
-        self.raw.get_bigint()
-    }
-
-    /// Current four-state value, or `Err` if VPI does not supply it.
-    pub fn get_logic(&self) -> Result<LogicArray, ValueError> {
-        self.raw.get_logic()
-    }
-
-    /// Current four-state value formatted as an MSB-first binary string.
-    pub fn get_binstr(&self) -> Result<String, ValueError> {
-        Ok(self.raw.get_logic()?.to_binstr())
-    }
-
-    /// Convenience for 1-bit signals: true iff the value is 1b1.
-    pub fn is_high(&self) -> bool {
-        self.raw.get_bool() == Ok(true)
-    }
-
-    /// Convenience for 1-bit signals: true iff the value is 1b0.
-    pub fn is_low(&self) -> bool {
-        self.raw.get_bool() == Ok(false)
-    }
-
-    // ------ Write: scheduled (applied at next ReadWrite phase, row 22) ------
-
-    /// Set the boolean value to be applied at the next ReadWrite phase. The
-    /// write is buffered and the last write wins, preserving order of distinct
-    /// signals.
-    pub fn set_bool(&self, v: bool) {
-        phase::schedule(self.raw, phase::WriteVal::Bool(v));
-    }
-
-    /// Set the unsigned 8-bit value to be applied at the next ReadWrite phase.
-    /// The write is buffered and the last write wins, preserving order of
-    /// distinct signals.
-    pub fn set_u8(&self, v: u8) {
-        phase::schedule(self.raw, phase::WriteVal::U8(v));
-    }
-
-    /// Set the unsigned 16-bit value to be applied at the next ReadWrite phase.
-    /// The write is buffered and the last write wins, preserving order of
-    /// distinct signals.
-    pub fn set_u16(&self, v: u16) {
-        phase::schedule(self.raw, phase::WriteVal::U16(v));
-    }
-
-    /// Set the unsigned 32-bit value to be applied at the next ReadWrite phase.
-    /// The write is buffered and the last write wins, preserving order of
-    /// distinct signals.
-    pub fn set_u32(&self, v: u32) {
-        phase::schedule(self.raw, phase::WriteVal::U32(v));
-    }
-
-    /// Set the unsigned 64-bit value to be applied at the next ReadWrite phase.
-    /// The write is buffered and the last write wins, preserving order of
-    /// distinct signals.
-    pub fn set_u64(&self, v: u64) {
-        phase::schedule(self.raw, phase::WriteVal::U64(v));
-    }
-
-    /// Set the unsigned 128-bit value to be applied at the next ReadWrite
-    /// phase. The write is buffered and the last write wins, preserving order
-    /// of distinct signals.
-    pub fn set_u128(&self, v: u128) {
-        phase::schedule(self.raw, phase::WriteVal::U128(v));
-    }
-
-    /// Set the arbitrary-width unsigned value to be applied at the next
-    /// ReadWrite phase. The write is buffered and the last write wins,
-    /// preserving order of distinct signals.
-    pub fn set_bigint(&self, v: &BigUint) {
-        phase::schedule(self.raw, phase::WriteVal::BigInt(v.clone()));
-    }
-
-    /// Set the four-state value to be applied at the next ReadWrite phase. The
-    /// write is buffered and the last write wins, preserving order of distinct
-    /// signals.
-    pub fn set_logic(&self, v: &LogicArray) {
-        phase::schedule(self.raw, phase::WriteVal::Logic(v.clone()));
-    }
-
-    // -------------- write: immediate (setimmediatevalue analog) --------------
-    //
-    // Immediate skips the write *scheduler*, not the phase *rule* (D108). The
-    // rule is the simulator's: writing during ReadOnly is illegal however the
-    // write gets there. Left unchecked, these two went straight to
-    // `vpi_put_value` and Icarus swallowed them with a printed diagnostic —
-    // "attempted to put a value to variable 'x' during a read-only synch
-    // callback" — after which the run continued on values that were never
-    // applied. That is the worst kind of wrong: it looks like a warning and it
-    // silently changes results.
-
-    /// Set the boolean value immediately, skipping the write scheduler. The
-    /// write is applied at once, but the ReadOnly rule is still enforced.
-    pub fn set_bool_now(&self, v: bool) {
-        phase::deny_write_in_read_only(self.raw);
-        self.raw.set_bool_now(v);
-    }
-
-    /// Set the unsigned 8-bit value immediately, skipping the write scheduler.
-    /// The write is applied at once, but the ReadOnly rule is still enforced.
-    pub fn set_u8_now(&self, v: u8) {
-        phase::deny_write_in_read_only(self.raw);
-        self.raw.set_u8_now(v);
-    }
-
-    /// Set the unsigned 16-bit value immediately, skipping the write scheduler.
-    /// The write is applied at once, but the ReadOnly rule is still enforced.
-    pub fn set_u16_now(&self, v: u16) {
-        phase::deny_write_in_read_only(self.raw);
-        self.raw.set_u16_now(v);
-    }
-
-    /// Set the unsigned 32-bit value immediately, skipping the write scheduler.
-    /// The write is applied at once, but the ReadOnly rule is still enforced.
-    pub fn set_u32_now(&self, v: u32) {
-        phase::deny_write_in_read_only(self.raw);
-        self.raw.set_u32_now(v);
-    }
-
-    /// Set the unsigned 64-bit value immediately, skipping the write scheduler.
-    /// The write is applied at once, but the ReadOnly rule is still enforced.
-    pub fn set_u64_now(&self, v: u64) {
-        phase::deny_write_in_read_only(self.raw);
-        self.raw.set_u64_now(v);
-    }
-
-    /// Set the unsigned 128-bit value immediately, skipping the write
-    /// scheduler. The write is applied at once, but the ReadOnly rule is still
-    /// enforced.
-    pub fn set_u128_now(&self, v: u128) {
-        phase::deny_write_in_read_only(self.raw);
-        self.raw.set_u128_now(v);
-    }
-
-    /// Set the arbitrary-width unsigned value immediately, skipping the write
-    /// scheduler. The write is applied at once, but the ReadOnly rule is still
-    /// enforced.
-    pub fn set_bigint_now(&self, v: &BigUint) {
-        phase::deny_write_in_read_only(self.raw);
-        self.raw.set_bigint_now(v);
-    }
-
-    /// Set the four-state value immediately, skipping the write scheduler. The
-    /// write is applied at once, but the ReadOnly rule is still enforced.
-    pub fn set_logic_now(&self, v: &LogicArray) {
-        phase::deny_write_in_read_only(self.raw);
-        self.raw.set_logic_now(v);
-    }
-
-    // ---- edges (methods on typed handles, mapping row 14) ----
-    pub fn rising_edge(&self) -> Edge {
-        Edge::new(self.raw, EdgeKind::Rising)
-    }
-    pub fn falling_edge(&self) -> Edge {
-        Edge::new(self.raw, EdgeKind::Falling)
-    }
-    pub fn value_change(&self) -> Edge {
-        Edge::new(self.raw, EdgeKind::AnyChange)
-    }
-}
-
-/// The `RUSTDV_TOP` module, or the first top-level module when it is unset.
-pub fn top_module() -> Result<HierarchyHandle, HandleError> {
-    Ok(HierarchyHandle {
-        raw: gpi::top_module()?,
-    })
+    /// Get the value change event for this handle
+    fn value_change(&self) -> Edge;
 }

--- a/rustdv/rustdv-sim/src/handle/aggregate.rs
+++ b/rustdv/rustdv-sim/src/handle/aggregate.rs
@@ -1,0 +1,41 @@
+//! Typed member access for structs and unions.
+
+use rustdv_gpi as gpi;
+
+use crate::handle::{HandleBase, HandleChildren, HandleError, SimHandle};
+
+/// An unpacked struct or union accessed through typed members.
+#[derive(Copy, Clone)]
+pub struct AggregateHandle {
+    pub(super) raw: gpi::AggregateHandle,
+}
+
+impl From<gpi::AggregateHandle> for AggregateHandle {
+    fn from(raw: gpi::AggregateHandle) -> Self {
+        AggregateHandle { raw }
+    }
+}
+
+impl HandleChildren for AggregateHandle {
+    fn child(&self, name: &str) -> Result<SimHandle, HandleError> {
+        Ok(SimHandle::wrap(self.raw.child(name)?))
+    }
+
+    fn children(&self) -> Vec<SimHandle> {
+        self.raw
+            .children()
+            .into_iter()
+            .map(SimHandle::wrap)
+            .collect()
+    }
+}
+
+impl HandleBase for AggregateHandle {
+    fn name(&self) -> String {
+        self.raw.name()
+    }
+
+    fn full_name(&self) -> String {
+        self.raw.full_name()
+    }
+}

--- a/rustdv/rustdv-sim/src/handle/hierarchy.rs
+++ b/rustdv/rustdv-sim/src/handle/hierarchy.rs
@@ -1,0 +1,65 @@
+//! Module lookup and typed child access.
+
+use rustdv_gpi as gpi;
+
+use crate::handle::{HandleBase, HandleChildren, HandleError, SimHandle};
+
+/// A module/scope handle: `dut.child("name")?` (OQ-6 dynamic-first lean).
+#[derive(Copy, Clone)]
+pub struct HierarchyHandle {
+    pub(super) raw: gpi::HierarchyHandle,
+}
+
+impl From<gpi::HierarchyHandle> for HierarchyHandle {
+    fn from(raw: gpi::HierarchyHandle) -> Self {
+        HierarchyHandle { raw }
+    }
+}
+
+impl HandleBase for HierarchyHandle {
+    fn name(&self) -> String {
+        self.raw.name()
+    }
+
+    fn full_name(&self) -> String {
+        self.raw.full_name()
+    }
+}
+
+impl HandleChildren for HierarchyHandle {
+    fn child(&self, name: &str) -> Result<SimHandle, HandleError> {
+        Ok(SimHandle::wrap(self.raw.child(name)?))
+    }
+
+    fn children(&self) -> Vec<SimHandle> {
+        self.raw
+            .children()
+            .into_iter()
+            .map(SimHandle::wrap)
+            .collect()
+    }
+}
+
+/// The `RUSTDV_TOP` module, or the first top-level module when it is unset.
+pub fn top_module() -> Result<HierarchyHandle, HandleError> {
+    Ok(HierarchyHandle::from(gpi::top_module()?))
+}
+
+impl std::fmt::Debug for HierarchyHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HierarchyHandle(\"{}\")", self.full_name())
+    }
+}
+
+impl HierarchyHandle {
+    /// A handle to nothing, for unit tests that need a `RustdvCtx` but never
+    /// touch the DUT. Any VPI call through it reaches `rustdv-vpi-stubs`,
+    /// which panics — so a test that *does* touch the DUT fails loudly rather
+    /// than reading garbage, and its author learns it belongs in a `sim-*`
+    /// case instead.
+    pub fn null_for_test() -> HierarchyHandle {
+        HierarchyHandle {
+            raw: gpi::HierarchyHandle::null_for_test(),
+        }
+    }
+}

--- a/rustdv/rustdv-sim/src/handle/logic.rs
+++ b/rustdv/rustdv-sim/src/handle/logic.rs
@@ -1,0 +1,245 @@
+//! Logic reads, scheduled writes, and edge triggers.
+
+use rustdv_gpi as gpi;
+
+use crate::{
+    LogicArray, ValueError,
+    handle::{BigUint, HandleBase, HandleEvent},
+    phase,
+    triggers::{Edge, EdgeKind},
+};
+
+/// A value-bearing signal. Explicit `get()`/`set()` (mapping row 20 —
+/// cocotb 2.x itself moved off the `.value` property).
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub struct LogicHandle {
+    pub(super) raw: gpi::LogicHandle,
+}
+
+impl From<gpi::LogicHandle> for LogicHandle {
+    fn from(raw: gpi::LogicHandle) -> Self {
+        LogicHandle { raw }
+    }
+}
+
+impl HandleBase for LogicHandle {
+    fn name(&self) -> String {
+        self.raw.name()
+    }
+
+    fn full_name(&self) -> String {
+        self.raw.full_name()
+    }
+}
+
+impl std::fmt::Debug for LogicHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LogicHandle(\"{}\")", self.full_name())
+    }
+}
+
+impl LogicHandle {
+    pub fn size(&self) -> u32 {
+        self.raw.size()
+    }
+
+    // ----------------- Read: current value (mapping row 19) -----------------
+
+    /// Current boolean value, or `Err` if VPI does not supply it.
+    pub fn get_bool(&self) -> Result<bool, ValueError> {
+        self.raw.get_bool()
+    }
+
+    /// Current unsigned 8-bit value, or `Err` if VPI does not supply it.
+    pub fn get_u8(&self) -> Result<u8, ValueError> {
+        self.raw.get_u8()
+    }
+    /// Current unsigned 16-bit value, or `Err` if VPI does not supply it.
+    pub fn get_u16(&self) -> Result<u16, ValueError> {
+        self.raw.get_u16()
+    }
+
+    /// Current unsigned 32-bit value, or `Err` if VPI does not supply it.
+    pub fn get_u32(&self) -> Result<u32, ValueError> {
+        self.raw.get_u32()
+    }
+
+    /// Current unsigned 64-bit value, or `Err` if VPI does not supply it.
+    pub fn get_u64(&self) -> Result<u64, ValueError> {
+        self.raw.get_u64()
+    }
+
+    /// Current unsigned 128-bit value, or `Err` if VPI does not supply it.
+    pub fn get_u128(&self) -> Result<u128, ValueError> {
+        self.raw.get_u128()
+    }
+
+    /// Current arbitrary-width unsigned value, or `Err` if VPI does not supply it.
+    pub fn get_bigint(&self) -> Result<BigUint, ValueError> {
+        self.raw.get_bigint()
+    }
+
+    /// Current four-state value, or `Err` if VPI does not supply it.
+    pub fn get_logic(&self) -> Result<LogicArray, ValueError> {
+        self.raw.get_logic()
+    }
+
+    /// Current four-state value formatted as an MSB-first binary string.
+    pub fn get_binstr(&self) -> Result<String, ValueError> {
+        Ok(self.raw.get_logic()?.to_binstr())
+    }
+
+    /// Convenience for 1-bit signals: true iff the value is 1b1.
+    pub fn is_high(&self) -> bool {
+        self.raw.get_bool() == Ok(true)
+    }
+
+    /// Convenience for 1-bit signals: true iff the value is 1b0.
+    pub fn is_low(&self) -> bool {
+        self.raw.get_bool() == Ok(false)
+    }
+
+    // ------ Write: scheduled (applied at next ReadWrite phase, row 22) ------
+
+    /// Set the boolean value to be applied at the next ReadWrite phase. The
+    /// write is buffered and the last write wins, preserving order of distinct
+    /// signals.
+    pub fn set_bool(&self, v: bool) {
+        phase::schedule(self.raw, phase::WriteVal::Bool(v));
+    }
+
+    /// Set the unsigned 8-bit value to be applied at the next ReadWrite phase.
+    /// The write is buffered and the last write wins, preserving order of
+    /// distinct signals.
+    pub fn set_u8(&self, v: u8) {
+        phase::schedule(self.raw, phase::WriteVal::U8(v));
+    }
+
+    /// Set the unsigned 16-bit value to be applied at the next ReadWrite phase.
+    /// The write is buffered and the last write wins, preserving order of
+    /// distinct signals.
+    pub fn set_u16(&self, v: u16) {
+        phase::schedule(self.raw, phase::WriteVal::U16(v));
+    }
+
+    /// Set the unsigned 32-bit value to be applied at the next ReadWrite phase.
+    /// The write is buffered and the last write wins, preserving order of
+    /// distinct signals.
+    pub fn set_u32(&self, v: u32) {
+        phase::schedule(self.raw, phase::WriteVal::U32(v));
+    }
+
+    /// Set the unsigned 64-bit value to be applied at the next ReadWrite phase.
+    /// The write is buffered and the last write wins, preserving order of
+    /// distinct signals.
+    pub fn set_u64(&self, v: u64) {
+        phase::schedule(self.raw, phase::WriteVal::U64(v));
+    }
+
+    /// Set the unsigned 128-bit value to be applied at the next ReadWrite
+    /// phase. The write is buffered and the last write wins, preserving order
+    /// of distinct signals.
+    pub fn set_u128(&self, v: u128) {
+        phase::schedule(self.raw, phase::WriteVal::U128(v));
+    }
+
+    /// Set the arbitrary-width unsigned value to be applied at the next
+    /// ReadWrite phase. The write is buffered and the last write wins,
+    /// preserving order of distinct signals.
+    pub fn set_bigint(&self, v: &BigUint) {
+        phase::schedule(self.raw, phase::WriteVal::BigInt(v.clone()));
+    }
+
+    /// Set the four-state value to be applied at the next ReadWrite phase. The
+    /// write is buffered and the last write wins, preserving order of distinct
+    /// signals.
+    pub fn set_logic(&self, v: &LogicArray) {
+        phase::schedule(self.raw, phase::WriteVal::Logic(v.clone()));
+    }
+
+    // -------------- write: immediate (setimmediatevalue analog) --------------
+    //
+    // Immediate skips the write *scheduler*, not the phase *rule* (D108). The
+    // rule is the simulator's: writing during ReadOnly is illegal however the
+    // write gets there. Left unchecked, these two went straight to
+    // `vpi_put_value` and Icarus swallowed them with a printed diagnostic —
+    // "attempted to put a value to variable 'x' during a read-only synch
+    // callback" — after which the run continued on values that were never
+    // applied. That is the worst kind of wrong: it looks like a warning and it
+    // silently changes results.
+
+    /// Set the boolean value immediately, skipping the write scheduler. The
+    /// write is applied at once, but the ReadOnly rule is still enforced.
+    pub fn set_bool_now(&self, v: bool) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_bool_now(v);
+    }
+
+    /// Set the unsigned 8-bit value immediately, skipping the write scheduler.
+    /// The write is applied at once, but the ReadOnly rule is still enforced.
+    pub fn set_u8_now(&self, v: u8) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_u8_now(v);
+    }
+
+    /// Set the unsigned 16-bit value immediately, skipping the write scheduler.
+    /// The write is applied at once, but the ReadOnly rule is still enforced.
+    pub fn set_u16_now(&self, v: u16) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_u16_now(v);
+    }
+
+    /// Set the unsigned 32-bit value immediately, skipping the write scheduler.
+    /// The write is applied at once, but the ReadOnly rule is still enforced.
+    pub fn set_u32_now(&self, v: u32) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_u32_now(v);
+    }
+
+    /// Set the unsigned 64-bit value immediately, skipping the write scheduler.
+    /// The write is applied at once, but the ReadOnly rule is still enforced.
+    pub fn set_u64_now(&self, v: u64) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_u64_now(v);
+    }
+
+    /// Set the unsigned 128-bit value immediately, skipping the write
+    /// scheduler. The write is applied at once, but the ReadOnly rule is still
+    /// enforced.
+    pub fn set_u128_now(&self, v: u128) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_u128_now(v);
+    }
+
+    /// Set the arbitrary-width unsigned value immediately, skipping the write
+    /// scheduler. The write is applied at once, but the ReadOnly rule is still
+    /// enforced.
+    pub fn set_bigint_now(&self, v: &BigUint) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_bigint_now(v);
+    }
+
+    /// Set the four-state value immediately, skipping the write scheduler. The
+    /// write is applied at once, but the ReadOnly rule is still enforced.
+    pub fn set_logic_now(&self, v: &LogicArray) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_logic_now(v);
+    }
+}
+
+impl HandleEvent for LogicHandle {
+    /// Get the rising edge event for this handle
+    fn rising_edge(&self) -> Edge {
+        Edge::new(self.raw, EdgeKind::Rising)
+    }
+
+    /// Get the falling edge event for this handle
+    fn falling_edge(&self) -> Edge {
+        Edge::new(self.raw, EdgeKind::Falling)
+    }
+
+    /// Get the value change event for this handle
+    fn value_change(&self) -> Edge {
+        Edge::new(self.raw, EdgeKind::AnyChange)
+    }
+}

--- a/rustdv/rustdv-sim/src/handle/real.rs
+++ b/rustdv/rustdv-sim/src/handle/real.rs
@@ -1,0 +1,44 @@
+//! Real values with scheduled and immediate writes.
+
+use rustdv_gpi as gpi;
+
+use crate::{
+    handle::{HandleBase, ValueError},
+    phase,
+};
+
+/// A real variable with scheduled and immediate writes.
+#[derive(Copy, Clone)]
+pub struct RealHandle {
+    pub(super) raw: gpi::RealHandle,
+}
+
+impl From<gpi::RealHandle> for RealHandle {
+    fn from(raw: gpi::RealHandle) -> Self {
+        RealHandle { raw }
+    }
+}
+
+impl HandleBase for RealHandle {
+    fn name(&self) -> String {
+        self.raw.name()
+    }
+
+    fn full_name(&self) -> String {
+        self.raw.full_name()
+    }
+}
+
+impl RealHandle {
+    pub fn get(&self) -> Result<f64, ValueError> {
+        self.raw.get()
+    }
+    /// Buffer a write until ReadWrite; the last write to this handle wins.
+    pub fn set(&self, value: f64) {
+        phase::schedule(self.raw, phase::WriteVal::Real(value));
+    }
+    pub fn set_now(&self, value: f64) {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_now(value);
+    }
+}

--- a/rustdv/rustdv-sim/src/handle/string.rs
+++ b/rustdv/rustdv-sim/src/handle/string.rs
@@ -1,0 +1,51 @@
+//! String values with scheduled and immediate writes.
+
+use rustdv_gpi as gpi;
+
+use crate::{
+    handle::{HandleBase, ValueError},
+    phase,
+};
+
+/// A string variable. Embedded NUL bytes are rejected by both write paths.
+#[derive(Copy, Clone)]
+pub struct StringHandle {
+    pub(super) raw: gpi::StringHandle,
+}
+
+impl From<gpi::StringHandle> for StringHandle {
+    fn from(raw: gpi::StringHandle) -> Self {
+        StringHandle { raw }
+    }
+}
+
+impl HandleBase for StringHandle {
+    fn name(&self) -> String {
+        self.raw.name()
+    }
+
+    fn full_name(&self) -> String {
+        self.raw.full_name()
+    }
+}
+
+impl StringHandle {
+    pub fn get(&self) -> Result<String, ValueError> {
+        self.raw.get()
+    }
+
+    /// Buffer an owned copy until ReadWrite; the last write wins.
+    pub fn set(&self, value: &str) -> Result<(), ValueError> {
+        phase::deny_write_in_read_only(self.raw);
+        if value.contains('\0') {
+            return Err(ValueError::InteriorNul);
+        }
+        phase::schedule(self.raw, phase::WriteVal::String(value.into()));
+        Ok(())
+    }
+
+    pub fn set_now(&self, value: &str) -> Result<(), ValueError> {
+        phase::deny_write_in_read_only(self.raw);
+        self.raw.set_now(value)
+    }
+}

--- a/rustdv/rustdv-sim/src/phase.rs
+++ b/rustdv/rustdv-sim/src/phase.rs
@@ -35,6 +35,39 @@ pub(crate) enum WriteVal {
     U128(u128),
     BigInt(BigUint),
     Logic(LogicArray),
+    Real(f64),
+    String(String),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+pub(crate) enum WriteTarget {
+    Logic(gpi::LogicHandle),
+    Real(gpi::RealHandle),
+    String(gpi::StringHandle),
+}
+impl WriteTarget {
+    fn full_name(self) -> String {
+        match self {
+            Self::Logic(h) => h.full_name(),
+            Self::Real(h) => h.full_name(),
+            Self::String(h) => h.full_name(),
+        }
+    }
+}
+impl From<gpi::LogicHandle> for WriteTarget {
+    fn from(h: gpi::LogicHandle) -> Self {
+        Self::Logic(h)
+    }
+}
+impl From<gpi::RealHandle> for WriteTarget {
+    fn from(h: gpi::RealHandle) -> Self {
+        Self::Real(h)
+    }
+}
+impl From<gpi::StringHandle> for WriteTarget {
+    fn from(h: gpi::StringHandle) -> Self {
+        Self::String(h)
+    }
 }
 
 struct Hub {
@@ -45,7 +78,7 @@ struct Hub {
     ro_cb: RefCell<Option<gpi::CallbackHandle>>,
     nt_waiters: RefCell<Vec<Weak<TrigShared>>>,
     nt_cb: RefCell<Option<gpi::CallbackHandle>>,
-    writes: RefCell<Vec<(gpi::LogicHandle, WriteVal)>>,
+    writes: RefCell<Vec<(WriteTarget, WriteVal)>>,
 }
 
 thread_local! {
@@ -113,7 +146,21 @@ pub async fn leave_read_only() {
 // Write scheduling
 // ---------------------------------------------------------------------------
 
-fn apply_write(h: gpi::LogicHandle, v: &WriteVal) {
+fn apply_write(target: WriteTarget, v: &WriteVal) {
+    match (target, v) {
+        (WriteTarget::Real(h), WriteVal::Real(x)) => {
+            h.set_now(*x);
+            return;
+        }
+        (WriteTarget::String(h), WriteVal::String(x)) => {
+            h.set_now(x).expect("scheduled string was validated");
+            return;
+        }
+        _ => {}
+    }
+    let WriteTarget::Logic(h) = target else {
+        unreachable!("write target/value mismatch")
+    };
     match v {
         WriteVal::Bool(x) => h.set_bool_now(*x),
         WriteVal::U8(x) => h.set_u8_now(*x),
@@ -123,12 +170,14 @@ fn apply_write(h: gpi::LogicHandle, v: &WriteVal) {
         WriteVal::U128(x) => h.set_u128_now(*x),
         WriteVal::BigInt(x) => h.set_bigint_now(x),
         WriteVal::Logic(x) => h.set_logic_now(x),
+        _ => unreachable!("write target/value mismatch"),
     }
 }
 
 /// The ReadOnly rule, in one place because both write paths owe it: the
-/// scheduled one below and the immediate one in `handle.rs` (D108).
-pub(crate) fn deny_write_in_read_only(h: gpi::LogicHandle) {
+/// scheduled one below and the immediate methods in the `handle` submodules (D108).
+pub(crate) fn deny_write_in_read_only(h: impl Into<WriteTarget>) {
+    let h = h.into();
     if hub().phase.get() == SimPhase::ReadOnly {
         panic!(
             "illegal write to '{}' during the ReadOnly phase (cocotb rule, design-doc §4.4)",
@@ -137,7 +186,8 @@ pub(crate) fn deny_write_in_read_only(h: gpi::LogicHandle) {
     }
 }
 
-pub(crate) fn schedule(h: gpi::LogicHandle, v: WriteVal) {
+pub(crate) fn schedule(h: impl Into<WriteTarget>, v: WriteVal) {
+    let h = h.into();
     let hub = hub();
     match hub.phase.get() {
         SimPhase::ReadOnly => deny_write_in_read_only(h),

--- a/rustdv/rustdv-sim/src/rustdv_sim.rs
+++ b/rustdv/rustdv-sim/src/rustdv_sim.rs
@@ -31,7 +31,9 @@ pub mod triggers;
 pub use clock::Clock;
 pub use combinators::{Either, TimeoutError, first2, join_all, join2, with_timeout};
 pub use executor::{Executor, TaskError, TaskHandle, TaskId, TaskState, spawn, spawn_named};
-pub use handle::{AnyHandle, HierarchyHandle, LogicHandle};
+pub use handle::{
+    AggregateHandle, HierarchyHandle, LogicHandle, RealHandle, SimHandle, StringHandle,
+};
 pub use path::RustdvPath;
 pub use phase::{next_time_step, read_only, read_write};
 pub use queue::Queue;

--- a/rustdv/rustdv-vpi-stubs/src/rustdv_vpi_stubs.rs
+++ b/rustdv/rustdv-vpi-stubs/src/rustdv_vpi_stubs.rs
@@ -40,6 +40,7 @@ struct StubCallback {
 }
 
 struct StubSignal {
+    object_type: i32,
     width: i32,
     words: Vec<t_vpi_vecval>,
     vector_value_available: bool,
@@ -55,6 +56,7 @@ struct StubTopIterator {
 impl Default for StubSignal {
     fn default() -> Self {
         Self {
+            object_type: vpiNet,
             width: 37,
             words: vec![t_vpi_vecval::default(); 2],
             vector_value_available: true,
@@ -92,12 +94,21 @@ pub fn configure_signal(width: i32, words: &[t_vpi_vecval], binstr: &str) {
     );
     SIGNAL.with(|signal| {
         *signal.borrow_mut() = StubSignal {
+            object_type: vpiNet,
             width,
             words: words[..word_count].to_vec(),
             vector_value_available: true,
             binstr: CString::new(binstr).expect("stub binary string contains NUL"),
             last_put: Vec::new(),
         };
+    });
+}
+
+/// Configure the type of the unit-test signal.
+pub fn configure_signal_type(object_type: i32) {
+    SIGNAL.with(|signal| {
+        let mut signal = signal.borrow_mut();
+        signal.object_type = object_type;
     });
 }
 
@@ -286,7 +297,7 @@ pub extern "C" fn vpi_get(property: i32, handle: *mut c_void) -> i32 {
     if property == vpiType && top_index(handle).is_some() {
         vpiModule
     } else if property == vpiType {
-        vpiNet
+        SIGNAL.with(|signal| signal.borrow().object_type)
     } else if property == vpiSize {
         SIGNAL.with(|signal| signal.borrow().width)
     } else {

--- a/rustdv/src/rustdv.rs
+++ b/rustdv/src/rustdv.rs
@@ -44,10 +44,12 @@ pub use rustdv_runner::{TEST_REGISTRATIONS, TestRegistration};
 pub use rustdv_sim::handle::top_module;
 pub use rustdv_sim::log;
 pub use rustdv_sim::{
-    AnyHandle, BigUint, Clock, Either, Event, Executor, HandleError, HierarchyHandle, Lock,
-    LockGuard, Logic, LogicArray, LogicHandle, NullTrigger, Queue, Rng, RustdvPath, SimDuration,
-    TaskError, TaskHandle, TaskState, TimeoutError, Timer, ValueError, first2, join2,
-    next_time_step, read_only, read_write, sim_time_ns, sim_time_steps, spawn, spawn_named,
+    AggregateHandle, BigUint, Clock, Either, Event, Executor, HandleError, HierarchyHandle, Lock,
+    LockGuard, Logic, LogicArray, LogicHandle, NullTrigger, Queue, RealHandle, Rng, RustdvPath,
+    SimDuration, SimHandle, StringHandle, TaskError, TaskHandle, TaskState, TimeoutError, Timer,
+    ValueError, first2,
+    handle::{HandleChildren, HandleEvent},
+    join2, next_time_step, read_only, read_write, sim_time_ns, sim_time_steps, spawn, spawn_named,
     with_timeout,
 };
 
@@ -80,16 +82,17 @@ pub use rustdv_methodology::Component;
 pub mod prelude {
     pub use crate::log;
     pub use crate::{
-        Active, AnalysisBus, BigUint, CheckSink, Clock, Component, ComponentNode, ConfigDb, Either,
-        Event, Factory, GetPort, HandleError, HierarchyHandle, Lock, Logic, LogicArray,
-        LogicHandle, NullTrigger, ObjectionGuard, PeekPort, PortName, PortOwner, PublishPort,
-        PutPort, Queue, Receiver, Rng, RustdvComp, RustdvCtx, RustdvSeq, RustdvShared, Sender,
-        SeqCtx, SeqError, SeqItem, SeqItemExport, SeqItemPort, Sequence, Sequencer, SimDuration,
-        SubscribePort, Subscriber, TaskHandle, TestError, Timer, TlmFifo, TxnId, build_all,
-        channel, check_all, connect_all, create_seq, end_of_elaboration_all, extract_all,
-        final_all, first2, join2, next_time_step, print_hierarchy, read_only, read_write,
-        report_all, run_component_test, run_extract_check_report, set_seq_override, sim_time_ns,
-        spawn, spawn_named, start_all, start_of_simulation_all, with_timeout,
+        Active, AggregateHandle, AnalysisBus, BigUint, CheckSink, Clock, Component, ComponentNode,
+        ConfigDb, Either, Event, Factory, GetPort, HandleChildren, HandleError, HandleEvent,
+        HierarchyHandle, Lock, Logic, LogicArray, LogicHandle, NullTrigger, ObjectionGuard,
+        PeekPort, PortName, PortOwner, PublishPort, PutPort, Queue, RealHandle, Receiver, Rng,
+        RustdvComp, RustdvCtx, RustdvSeq, RustdvShared, Sender, SeqCtx, SeqError, SeqItem,
+        SeqItemExport, SeqItemPort, Sequence, Sequencer, SimDuration, StringHandle, SubscribePort,
+        Subscriber, TaskHandle, TestError, Timer, TlmFifo, TxnId, build_all, channel, check_all,
+        connect_all, create_seq, end_of_elaboration_all, extract_all, final_all, first2, join2,
+        next_time_step, print_hierarchy, read_only, read_write, report_all, run_component_test,
+        run_extract_check_report, set_seq_override, sim_time_ns, spawn, spawn_named, start_all,
+        start_of_simulation_all, with_timeout,
     };
 }
 


### PR DESCRIPTION
Add typed handles for real values, strings, and unpacked struct/union aggregates. Real and string writes use the existing scheduled/immediate write rules and ReadOnly guards; aggregate members can be accessed through typed child handles.

Split simulator handles into dedicated modules and expose fallible SimHandle conversions with WrongKind errors. Update public exports and documentation, and add six Verilator-only simulator tests covering values, scheduling, nested aggregates, union aliasing, and handle conversions.
