### PR TITLE
Enforce strict Clippy and run Icarus tests on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Run Clippy
-        run: cargo clippy --workspace --all-targets
+        run: cargo clippy --workspace --all-targets -- -D warnings
 
   # Book-sync + all figure examples (build, run vs goldens, compile-fail,
   # unit tests). Simulator tests auto-skip here (no iverilog installed).
@@ -149,10 +149,8 @@ jobs:
           path: regress.log
           if-no-files-found: ignore
 
-  # Free-simulator validation. Linux runs every simulator entry; macOS runs
-  # the Verilator entries that exercise runtime loading, scheduling, callback
-  # ownership and the mutation check. Commercial simulators cannot run in
-  # public CI.
+  # Free-simulator validation. Linux and macOS run every Icarus and Verilator
+  # simulator entry. Commercial simulators cannot run in public CI.
   sim-smoke:
     strategy:
       fail-fast: false
@@ -161,7 +159,7 @@ jobs:
           - os: ubuntu-latest
             filter: sim
           - os: macos-latest
-            filter: verilator
+            filter: sim
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ repository at ../rustdv-reference, so the repo carries only its own product.
   by running things — transcripts in the book/README files are real output
   and must stay in sync with reruns.
 - After editing Rust code, run `cargo fmt` and
-  `cargo clippy --workspace --all-targets` from the repository root before
+  `cargo clippy --workspace --all-targets -- -D warnings` from the repository root before
   handing off the change.
 
 ### Leave no documentation debt — the rule that costs the most when ignored

--- a/output/regression/TESTING.md
+++ b/output/regression/TESTING.md
@@ -94,8 +94,8 @@ simulator assertion is visible in CI.
 ## Continuous integration
 
 `.github/workflows/ci.yml` runs the full no-simulator regression plus a
-free-simulator matrix. Linux runs the Icarus and Verilator entries; macOS
-repeats the Verilator runtime, scheduler, DEBUG/FST, and mutation entries.
+free-simulator matrix. Linux and macOS both run all Icarus and Verilator
+entries, including scheduler, DEBUG/FST, and mutation checks.
 Both simulator jobs build and cache Icarus 13.0 via `ci/install-iverilog.sh`.
 Icarus 12 has a next-time callback re-registration bug exercised by the phase
 regression; CI verifies the selected version before running tests.

--- a/rustdv/framework-tests/src/framework_tests.rs
+++ b/rustdv/framework-tests/src/framework_tests.rs
@@ -82,6 +82,14 @@ pub mod signals;
 pub mod sv_types;
 pub mod triggers;
 
+/// Measures how many simulator time steps make one nanosecond
+pub async fn steps_per_ns() -> u64 {
+    let (t0_steps, t0_ns) = (rustdv::sim_time_steps(), sim_time_ns());
+    Timer::ns(1).await;
+    let _ = t0_ns;
+    rustdv::sim_time_steps() - t0_steps
+}
+
 #[cfg(test)]
 mod registry_tests {
     #[test]
@@ -101,18 +109,4 @@ mod registry_tests {
             "ElabConnectedTreeIsClean"
         );
     }
-}
-
-/// How many simulator time steps make one nanosecond, measured rather than
-/// assumed.
-///
-/// `probe.sv` says `1ns/1ns`, but a test that hard-codes the ratio breaks
-/// silently the day someone changes the timescale — it would still pass, on
-/// the wrong numbers. Advancing a known 1ns and reading both clocks gives the
-/// ratio and proves the two time functions agree on the way past.
-pub async fn steps_per_ns() -> u64 {
-    let (t0_steps, t0_ns) = (rustdv::sim_time_steps(), sim_time_ns());
-    Timer::ns(1).await;
-    let _ = t0_ns;
-    rustdv::sim_time_steps() - t0_steps
 }

--- a/rustdv/framework-tests/src/triggers.rs
+++ b/rustdv/framework-tests/src/triggers.rs
@@ -377,7 +377,8 @@ async fn trig_phase_order_within_a_step(ctx: RustdvCtx) -> Result<(), TestError>
     );
 
     next_time_step().await;
-    check!(sim_time_ns() > t0, "NextTimeStep did not advance past {t0}");
+    let advanced = sim_time_ns() > t0;
+    check!(advanced, "NextTimeStep did not advance past {t0}");
     Ok(())
 }
 

--- a/rustdv/rustdv-sim/src/combinators.rs
+++ b/rustdv/rustdv-sim/src/combinators.rs
@@ -269,7 +269,7 @@ mod tests {
     #[test]
     fn joined_futures_may_borrow() {
         block_on(async {
-            let owned = vec![1u8, 2, 3];
+            let owned = [1u8, 2, 3];
             let borrow_a = async { owned.len() };
             let borrow_b = async { owned[0] as usize };
             let (a, b) = join2(borrow_a, borrow_b).await;

--- a/rustdv/tinyalu_tb/src/alu_bfm.rs
+++ b/rustdv/tinyalu_tb/src/alu_bfm.rs
@@ -180,10 +180,11 @@ impl TinyAluBfm {
                 async move {
                     loop {
                         clk.falling_edge().await;
-                        if start.is_high() && done.is_high() {
-                            if let Ok(r) = result.get_u64() {
-                                let _ = q.try_put(AluResult { result: r as u16 });
-                            }
+                        if start.is_high()
+                            && done.is_high()
+                            && let Ok(r) = result.get_u64()
+                        {
+                            let _ = q.try_put(AluResult { result: r as u16 });
                         }
                     }
                 },


### PR DESCRIPTION
Make Clippy CI fail on warnings by running cargo clippy --workspace --all-targets -- -D warnings, and align CLAUDE.md with that command. Fix the remaining warnings in framework tests and the TinyALU BFM.

Run the full Icarus and Verilator simulator selection on macOS as well as Ubuntu, and update the CI documentation.

Validation: formatting, strict workspace Clippy, workspace tests, Icarus trigger tests, and book-listing checks pass locally. Workflow YAML validates.
